### PR TITLE
Refactor/17 change file path for raw data to have releases at root level

### DIFF
--- a/src/application/common/doppa_logger.py
+++ b/src/application/common/doppa_logger.py
@@ -6,9 +6,8 @@ from src import Config
 
 warnings.filterwarnings(
     "ignore",
-    message="Geometry column does not contain geometry",
-    category=UserWarning,
-    module="geopandas"
+    message="Geometry column does not contain geometry\\.",
+    category=UserWarning
 )
 
 Config.LOG_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/src/application/contracts/file_path_service_interface.py
+++ b/src/application/contracts/file_path_service_interface.py
@@ -5,23 +5,23 @@ from src.domain.enums import Theme
 
 class IFilePathService(ABC):
     @abstractmethod
-    def create_storage_account_file_path(
+    def create_dataset_blob_path(
             self,
             release: str,
             theme: Theme,
             region: str,
             file_name: str,
-            prefix: str = None
+            **kwargs
     ) -> str:
         """
-        Creates a storage account file path based on the provided parameters.
+        Creates a storage account file path to a dataset blob. On the format `release/{release}/**kwargs/theme={theme}/region={region}/{file_name}`
 
         :param release: Release version in the format 'yyyy-mm-dd.x'
         :param theme: Theme enum value
         :param region: A region in Norway is defined as county. For example '03' for Oslo
         :param file_name: File name to store. Must be in the format 'part_xxxxx.parquet'
         :return: Storage path
-        :param prefix: Prefix to add at the start of the path
+        :param kwargs: Additional keyword arguments that will be added between release and theme
         :rtype: str
         """
         raise NotImplementedError

--- a/src/config.py
+++ b/src/config.py
@@ -47,7 +47,7 @@ class Config:
     FKB_WGS84_BUILDINGS_PARQUET_PATH: Path = FKB_DIR / "fkb_wgs84_buildings.parquet"
 
     # GEONORGE
-    GEONORGE_BASE_URL: str = "https://api.test.kartverket.no/kommuneinfo/v1/"
+    GEONORGE_BASE_URL: str = "https://api.kartverket.no/kommuneinfo/v1/"
 
     # METADATA
     RELEASE_FILE_NAME = "releases.parquet"

--- a/src/infra/infrastructure/services/file_path_service.py
+++ b/src/infra/infrastructure/services/file_path_service.py
@@ -6,16 +6,18 @@ from src.domain.enums import Theme
 
 
 class FilePathService(IFilePathService):
-    def create_storage_account_file_path(
+    def create_dataset_blob_path(
             self,
             release: str,
             theme: Theme,
             region: str,
             file_name: str,
-            prefix: str = None
+            **kwargs
     ) -> str:
         FilePathService.validate_file_path(release=release, region=region, file_name=file_name)
-        return f"release/{release}/theme={theme.value}/region={region}/{file_name}" if prefix is None else f"{prefix}/release/{release}/theme={theme.value}/region={region}/{file_name}"
+        kwarg_parts = "/".join([f"{key}={value}" for key, value in kwargs.items()]) if kwargs else ""
+        middle = f"{kwarg_parts}/" if kwarg_parts else ""
+        return f"release/{release}/{middle}theme={theme.value}/region={region}/{file_name}"
 
     @staticmethod
     def validate_file_path(release: str, region: str, file_name: str) -> None:

--- a/src/infra/infrastructure/services/file_path_service.py
+++ b/src/infra/infrastructure/services/file_path_service.py
@@ -15,8 +15,7 @@ class FilePathService(IFilePathService):
             **kwargs
     ) -> str:
         FilePathService.validate_file_path(release=release, region=region, file_name=file_name)
-        kwarg_parts = "/".join([f"{key}={value}" for key, value in kwargs.items()]) if kwargs else ""
-        middle = f"{kwarg_parts}/" if kwarg_parts else ""
+        middle = '/'.join([f'{key}={value}' for key, value in kwargs.items()]) + '/' if kwargs else ''
         return f"release/{release}/{middle}theme={theme.value}/region={region}/{file_name}"
 
     @staticmethod

--- a/src/infra/infrastructure/services/open_street_map_service.py
+++ b/src/infra/infrastructure/services/open_street_map_service.py
@@ -78,12 +78,12 @@ class OpenStreetMapService(IOpenStreetMapService):
         Each partition becomes its own file to avoid overwriting.
         """
         for index, partition in enumerate(partitions):
-            storage_path = self.__file_path_service.create_storage_account_file_path(
+            storage_path = self.__file_path_service.create_dataset_blob_path(
                 release=release,
                 theme=Theme.BUILDINGS,
                 region=region,
                 file_name=f"part_{index:05d}.parquet",
-                prefix="osm",
+                dataset="osm"
             )
 
             with BytesIO() as buffer:


### PR DESCRIPTION
This pull request refactors the file path service interface and its implementation to improve flexibility in dataset blob path construction, updates usage accordingly, and makes minor configuration and warning filter adjustments. The most significant changes are the renaming and enhancement of the file path method to support arbitrary path components, and updating all usages to match the new interface.

### File Path Service Refactor

* Renamed the method `create_storage_account_file_path` to `create_dataset_blob_path` in both the `IFilePathService` interface (`file_path_service_interface.py`) and its implementation (`file_path_service.py`), and updated the method signature to accept arbitrary keyword arguments (`**kwargs`) instead of a `prefix` parameter. The method now constructs paths with any number of additional components between `release` and `theme`, increasing flexibility. [[1]](diffhunk://#diff-f83c7374fb73bcf97a66cc85f2e82ac40f0c7b65e22c3be3e0c6dc72c8c49e33L8-R24) [[2]](diffhunk://#diff-3eadca0abc50155e32036729b6c7b8179beb63be5e04e057c21df62d8d34338bL9-R20)
* Updated all usages of the file path method, such as in `open_street_map_service.py`, to use the new `create_dataset_blob_path` method and to pass additional path components as keyword arguments (e.g., `dataset="osm"` instead of `prefix="osm"`).

### Configuration and Warning Filter Updates

* Updated the `GEONORGE_BASE_URL` in `config.py` from the test API endpoint to the production endpoint.
* Adjusted the warning filter in `doppa_logger.py` to match the full message string including the period, ensuring proper suppression of the intended warning.