### PR TITLE
#20 Added Azure extension to db context

### DIFF
--- a/src/infra/persistence/context/duckdb.py
+++ b/src/infra/persistence/context/duckdb.py
@@ -10,13 +10,13 @@ def create_duckdb_context() -> duckdb.DuckDBPyConnection:
     db_context.install_extension("azure")
     db_context.load_extension("azure")
 
-    db_context.execute(f"""
+    db_context.execute("""
     CREATE OR REPLACE SECRET azure_secret(
         TYPE azure,
-        CONNECTION_STRING '{Config.BLOB_STORAGE_CONNECTION_STRING}'
+        CONNECTION_STRING ?
     );
-    """)
+    """, [Config.BLOB_STORAGE_CONNECTION_STRING])
 
-    db_context.execute(f"SET azure_storage_connection_string = '{Config.BLOB_STORAGE_CONNECTION_STRING}';")
+    db_context.execute("SET azure_storage_connection_string = ?;", [Config.BLOB_STORAGE_CONNECTION_STRING])
 
     return db_context

--- a/src/infra/persistence/context/duckdb.py
+++ b/src/infra/persistence/context/duckdb.py
@@ -1,8 +1,22 @@
 ﻿import duckdb
 
+from src import Config
+
+
 def create_duckdb_context() -> duckdb.DuckDBPyConnection:
     db_context: duckdb.DuckDBPyConnection = duckdb.connect()
     db_context.install_extension("spatial")
     db_context.load_extension("spatial")
+    db_context.install_extension("azure")
+    db_context.load_extension("azure")
+
+    db_context.execute(f"""
+    CREATE OR REPLACE SECRET azure_secret(
+        TYPE azure,
+        CONNECTION_STRING '{Config.BLOB_STORAGE_CONNECTION_STRING}'
+    );
+    """)
+
+    db_context.execute(f"SET azure_storage_connection_string = '{Config.BLOB_STORAGE_CONNECTION_STRING}';")
 
     return db_context

--- a/src/presentation/notebooks/01-1-blob-storage-validation.ipynb
+++ b/src/presentation/notebooks/01-1-blob-storage-validation.ipynb
@@ -3,24 +3,25 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-10-25T09:59:06.426096Z",
-     "start_time": "2025-10-25T09:59:06.414541Z"
+     "end_time": "2025-10-27T11:21:17.510782Z",
+     "start_time": "2025-10-27T11:21:16.713394Z"
     }
    },
    "cell_type": "code",
    "source": [
     "import geopandas as gpd\n",
-    "from src import Config"
+    "from src import Config\n",
+    "from src.infra.persistence.context import create_duckdb_context"
    ],
    "id": "4594a3c8665635b1",
    "outputs": [],
-   "execution_count": 6
+   "execution_count": 1
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-10-25T09:59:06.494107Z",
-     "start_time": "2025-10-25T09:59:06.490919Z"
+     "end_time": "2025-10-27T11:21:17.664185Z",
+     "start_time": "2025-10-27T11:21:17.661275Z"
     }
    },
    "cell_type": "code",
@@ -32,13 +33,19 @@
    ],
    "id": "d4da8645178c77b8",
    "outputs": [],
-   "execution_count": 7
+   "execution_count": 2
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "### View data using GeoPandas",
+   "id": "24f6f4deb55fa87"
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-10-25T09:59:14.880202Z",
-     "start_time": "2025-10-25T09:59:06.515399Z"
+     "end_time": "2025-10-27T11:21:37.889715Z",
+     "start_time": "2025-10-27T11:21:17.684213Z"
     }
    },
    "cell_type": "code",
@@ -59,13 +66,13 @@
    ],
    "id": "2a43359d4de3a9b8",
    "outputs": [],
-   "execution_count": 8
+   "execution_count": 3
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-10-25T09:59:14.907215Z",
-     "start_time": "2025-10-25T09:59:14.897734Z"
+     "end_time": "2025-10-27T11:21:37.931459Z",
+     "start_time": "2025-10-27T11:21:37.919198Z"
     }
    },
    "cell_type": "code",
@@ -167,18 +174,18 @@
        "</div>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 9
+   "execution_count": 4
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-10-25T09:59:17.976006Z",
-     "start_time": "2025-10-25T09:59:17.967806Z"
+     "end_time": "2025-10-27T11:21:37.989908Z",
+     "start_time": "2025-10-27T11:21:37.980023Z"
     }
    },
    "cell_type": "code",
@@ -280,25 +287,170 @@
        "</div>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 10
+   "execution_count": 5
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "### View data using DuckDB",
+   "id": "91112bd02a3f71"
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-10-25T09:59:15.122430Z",
-     "start_time": "2025-10-25T09:59:15.119592Z"
+     "end_time": "2025-10-27T11:21:52.619872Z",
+     "start_time": "2025-10-27T11:21:38.113218Z"
     }
    },
    "cell_type": "code",
-   "source": "",
-   "id": "d5467b38dcffee70",
+   "source": [
+    "path = \"az://raw/release/2025-10-27.8/datset=osm/theme=buildings/region=34/*.parquet\"\n",
+    "\n",
+    "db_context = create_duckdb_context()\n",
+    "df = db_context.execute(f\"\"\"\n",
+    "SELECT * FROM '{path}'\n",
+    "\"\"\").fetchdf()"
+   ],
+   "id": "9673be25e54d33d6",
    "outputs": [],
-   "execution_count": null
+   "execution_count": 6
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-10-27T11:21:52.679890Z",
+     "start_time": "2025-10-27T11:21:52.664440Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "df.head()",
+   "id": "4b0a3aa9850e14a3",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "            type ref:bygningsnr        id  \\\n",
+       "0         school      300681410  52578874   \n",
+       "1  sports_centre       13778086  56575688   \n",
+       "2  sports_centre        7224745  58465580   \n",
+       "3         retail       20437928  67305952   \n",
+       "4           farm      140325082  67815114   \n",
+       "\n",
+       "                                            geometry  \\\n",
+       "0  [5, 4, 0, 0, 0, 0, 0, 0, 118, 108, 39, 65, 182...   \n",
+       "1  [5, 4, 0, 0, 0, 0, 0, 0, 46, 152, 49, 65, 244,...   \n",
+       "2  [5, 4, 0, 0, 0, 0, 0, 0, 232, 98, 53, 65, 116,...   \n",
+       "3  [5, 4, 0, 0, 0, 0, 0, 0, 123, 174, 42, 65, 34,...   \n",
+       "4  [5, 4, 0, 0, 0, 0, 0, 0, 148, 249, 39, 65, 70,...   \n",
+       "\n",
+       "                                                bbox datset  region      theme  \n",
+       "0  {'xmin': 10.4639806, 'ymin': 61.1325323, 'xmax...    osm      34  buildings  \n",
+       "1  {'xmin': 11.099654, 'ymin': 60.791947, 'xmax':...    osm      34  buildings  \n",
+       "2  {'xmin': 11.3366477, 'ymin': 60.8178282, 'xmax...    osm      34  buildings  \n",
+       "3  {'xmin': 10.6675984, 'ymin': 60.7862631, 'xmax...    osm      34  buildings  \n",
+       "4  {'xmin': 10.498433, 'ymin': 60.3869887, 'xmax'...    osm      34  buildings  "
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>type</th>\n",
+       "      <th>ref:bygningsnr</th>\n",
+       "      <th>id</th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>bbox</th>\n",
+       "      <th>datset</th>\n",
+       "      <th>region</th>\n",
+       "      <th>theme</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>school</td>\n",
+       "      <td>300681410</td>\n",
+       "      <td>52578874</td>\n",
+       "      <td>[5, 4, 0, 0, 0, 0, 0, 0, 118, 108, 39, 65, 182...</td>\n",
+       "      <td>{'xmin': 10.4639806, 'ymin': 61.1325323, 'xmax...</td>\n",
+       "      <td>osm</td>\n",
+       "      <td>34</td>\n",
+       "      <td>buildings</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>sports_centre</td>\n",
+       "      <td>13778086</td>\n",
+       "      <td>56575688</td>\n",
+       "      <td>[5, 4, 0, 0, 0, 0, 0, 0, 46, 152, 49, 65, 244,...</td>\n",
+       "      <td>{'xmin': 11.099654, 'ymin': 60.791947, 'xmax':...</td>\n",
+       "      <td>osm</td>\n",
+       "      <td>34</td>\n",
+       "      <td>buildings</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>sports_centre</td>\n",
+       "      <td>7224745</td>\n",
+       "      <td>58465580</td>\n",
+       "      <td>[5, 4, 0, 0, 0, 0, 0, 0, 232, 98, 53, 65, 116,...</td>\n",
+       "      <td>{'xmin': 11.3366477, 'ymin': 60.8178282, 'xmax...</td>\n",
+       "      <td>osm</td>\n",
+       "      <td>34</td>\n",
+       "      <td>buildings</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>retail</td>\n",
+       "      <td>20437928</td>\n",
+       "      <td>67305952</td>\n",
+       "      <td>[5, 4, 0, 0, 0, 0, 0, 0, 123, 174, 42, 65, 34,...</td>\n",
+       "      <td>{'xmin': 10.6675984, 'ymin': 60.7862631, 'xmax...</td>\n",
+       "      <td>osm</td>\n",
+       "      <td>34</td>\n",
+       "      <td>buildings</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>farm</td>\n",
+       "      <td>140325082</td>\n",
+       "      <td>67815114</td>\n",
+       "      <td>[5, 4, 0, 0, 0, 0, 0, 0, 148, 249, 39, 65, 70,...</td>\n",
+       "      <td>{'xmin': 10.498433, 'ymin': 60.3869887, 'xmax'...</td>\n",
+       "      <td>osm</td>\n",
+       "      <td>34</td>\n",
+       "      <td>buildings</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 7
   }
  ],
  "metadata": {


### PR DESCRIPTION
This pull request enhances Azure Blob Storage integration with DuckDB and improves the corresponding Jupyter notebook for validating blob storage access. The main changes involve updating the DuckDB context to support Azure extensions and secrets, and expanding the notebook with practical examples for loading and viewing data from Azure Blob Storage using DuckDB.

**Azure Blob Storage integration in DuckDB:**

* The `create_duckdb_context` function now installs and loads the DuckDB Azure extension, creates a DuckDB secret for Azure using the connection string from `Config`, and sets the DuckDB session variable for the Azure storage connection string. This allows seamless querying of data stored in Azure Blob Storage from DuckDB.

**Notebook improvements for blob storage validation:**

* The notebook `01-1-blob-storage-validation.ipynb` is updated to import the new `create_duckdb_context` function, demonstrating how to connect to and query Parquet files directly from Azure Blob Storage using DuckDB. [[1]](diffhunk://#diff-c590534c116a833562ab9dce3277a69a0da80b0a394c9466f7bf269a80414579L6-R24) [[2]](diffhunk://#diff-c590534c116a833562ab9dce3277a69a0da80b0a394c9466f7bf269a80414579L283-R453)
* Added new markdown and code cells that guide users through viewing data with both GeoPandas and DuckDB, including a practical example of loading and displaying data from Azure. [[1]](diffhunk://#diff-c590534c116a833562ab9dce3277a69a0da80b0a394c9466f7bf269a80414579L35-R48) [[2]](diffhunk://#diff-c590534c116a833562ab9dce3277a69a0da80b0a394c9466f7bf269a80414579L283-R453)

These changes make it easier to access and validate spatial data stored in Azure Blob Storage within both Python scripts and interactive notebooks.