### PR TITLE
Feature/16 add region partitioning with geohashing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -105,6 +105,7 @@ psutil==7.1.0
 pure_eval==0.2.3
 pyarrow==21.0.0
 pycparser==2.23
+pygeohash==3.2.0
 Pygments==2.19.2
 PyJWT==2.10.1
 pyogrio==0.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,7 @@ geojson==3.2.0
 geopandas==1.1.1
 geopy==2.4.1
 h11==0.16.0
+h3==4.3.1
 httpcore==1.0.9
 httpx==0.28.1
 idna==3.10

--- a/src/application/contracts/vector_service_interface.py
+++ b/src/application/contracts/vector_service_interface.py
@@ -6,7 +6,7 @@ from src.domain.enums import EPSGCode
 
 class IVectorService(ABC):
     @abstractmethod
-    def partition_dataframe(self, dataframe: gpd.GeoDataFrame, batch_size: int) -> list[gpd.GeoDataFrame]:
+    def partition_dataframe(self, dataframe: gpd.GeoDataFrame ) -> list[gpd.GeoDataFrame]:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/config.py
+++ b/src/config.py
@@ -38,7 +38,6 @@ class Config:
     OSM_BUILDINGS_CLEANED_PARQUET_PATH: Path = DATASETS_PATH / "osm" / "cleaned_buildings.parquet"
     OSM_PBF_URL: str = "https://download.geofabrik.de/europe/norway-latest.osm.pbf"
     OSM_STREAMING_CHUNK_SIZE: int = 8192
-    OSM_FEATURE_BATCH_SIZE: int = 250_000
     OSM_COLUMNS_TO_KEEP: tuple[str, ...] = "id", "geometry", "building", "ref:bygningsnr"
 
     # FKB
@@ -71,3 +70,7 @@ class Config:
     FKB_LAYERS: tuple[str, ...] = (
         "Bygning", "AnnenBygning", "Takkant", "Bygningsdelelinje", "FiktivBygningsavgrensning"
     )
+
+    # PARTITIONING
+    PARTITION_RESOLUTION: int = 3
+    OSM_FEATURE_BATCH_SIZE: int = 250_000  # TODO: Rename this to FEATURE_BATCH_SIZE

--- a/src/infra/infrastructure/services/vector_service.py
+++ b/src/infra/infrastructure/services/vector_service.py
@@ -14,7 +14,7 @@ class VectorService(IVectorService):
     def __init__(self, db_context: DuckDBPyConnection):
         self.__db_context = db_context
 
-    def partition_dataframe(self, dataframe: gpd.GeoDataFrame, batch_size: int) -> list[gpd.GeoDataFrame]:
+    def partition_dataframe(self, dataframe: gpd.GeoDataFrame) -> list[gpd.GeoDataFrame]:
         centroids = dataframe.geometry.centroid
         dataframe["partition_key"] = [
             phg.encode(lat, lon, precision=Config.PARTITION_RESOLUTION)

--- a/src/infra/infrastructure/services/vector_service.py
+++ b/src/infra/infrastructure/services/vector_service.py
@@ -15,6 +15,7 @@ class VectorService(IVectorService):
         self.__db_context = db_context
 
     def partition_dataframe(self, dataframe: gpd.GeoDataFrame) -> list[gpd.GeoDataFrame]:
+        dataframe = dataframe.copy()
         centroids = dataframe.geometry.centroid
         dataframe["partition_key"] = [
             phg.encode(lat, lon, precision=Config.PARTITION_RESOLUTION)


### PR DESCRIPTION
This pull request introduces a new geohash-based partitioning strategy for geospatial dataframes and updates configuration settings to support this approach. The most significant changes include replacing the previous batch-based partitioning with geohash partitioning, updating configuration parameters, and incorporating the `pygeohash` library.

Partitioning improvements:

* The `partition_dataframe` method in `vector_service.py` now partitions a `GeoDataFrame` by computing a geohash for each geometry's centroid (using the configured precision) and grouping by this geohash, rather than simply slicing by batch size. This enables spatially coherent partitioning.
* The `pygeohash` library is now imported to support geohash encoding for partitioning.

Configuration updates:

* Added `PARTITION_RESOLUTION` to `Config` to control geohash precision, and moved `OSM_FEATURE_BATCH_SIZE` under a new partitioning section with a note to rename it for clarity.
* Removed the previous definition of `OSM_FEATURE_BATCH_SIZE` from its old location in `Config` to avoid duplication.
* The `Config` class is now imported in `vector_service.py` to access partitioning configuration.