### PR TITLE
#39 Removed backslashes from string

### DIFF
--- a/src/infra/infrastructure/services/conflation_service.py
+++ b/src/infra/infrastructure/services/conflation_service.py
@@ -181,13 +181,13 @@ class ConflationService(IConflationService):
         fkb_filter = (
             "FALSE"
             if not ids_fkb
-            else f"external_id IN ({', '.join(f'\'{v}\'' for v in ids_fkb)})"
+            else f'external_id IN ({", ".join(f"'{v}'" for v in ids_fkb)})'
         )
 
         osm_filter = (
             "FALSE"
             if not ids_osm
-            else f"external_id IN ({', '.join(f'\'{v}\'' for v in ids_osm)})"
+            else f'external_id IN ({", ".join(f"'{v}'" for v in ids_osm)})'
         )
 
         df = self.__db_context.execute(


### PR DESCRIPTION
This pull request makes a minor change to the SQL filter string construction in the `merge_fkb_osm` method to improve readability and consistency in how quotes are handled.

- Refactored the string formatting for the `external_id IN (...)` SQL filters in the `merge_fkb_osm` method to use double quotes on the outside and single quotes around each value, improving readability and consistency.