### PR TITLE
#39 Fixed bug where f-string was unterminated

### DIFF
--- a/src/infra/infrastructure/services/conflation_service.py
+++ b/src/infra/infrastructure/services/conflation_service.py
@@ -178,17 +178,11 @@ class ConflationService(IConflationService):
         ids_fkb = ids[ids["fkb_id"].notna()]["fkb_id"].to_list()
         ids_osm = ids[ids["fkb_id"].isna() & ids["osm_id"].notna()]["osm_id"].to_list()
 
-        fkb_filter = (
-            "FALSE"
-            if not ids_fkb
-            else f'external_id IN ({", ".join(f"'{v}'" for v in ids_fkb)})'
-        )
+        ids_fkb_str = ", ".join(f"'{v}'" for v in ids_fkb)
+        ids_osm_str = ", ".join(f"'{v}'" for v in ids_osm)
 
-        osm_filter = (
-            "FALSE"
-            if not ids_osm
-            else f'external_id IN ({", ".join(f"'{v}'" for v in ids_osm)})'
-        )
+        fkb_filter = "FALSE" if not ids_fkb else f"external_id IN ({ids_fkb_str})"
+        osm_filter = "FALSE" if not ids_osm else f"external_id IN ({ids_osm_str})"
 
         df = self.__db_context.execute(
             f'''


### PR DESCRIPTION
This pull request refactors the way SQL filter strings are constructed for FKB and OSM IDs in the `merge_fkb_osm` method to improve readability and maintainability. The logic for building the filter strings is now separated into explicit string variables before use.

Refactoring for SQL filter construction:

* Refactored construction of the `fkb_filter` and `osm_filter` SQL filter strings by first joining the ID lists into string variables (`ids_fkb_str` and `ids_osm_str`), improving clarity and reducing code duplication. (`src/infra/infrastructure/services/conflation_service.py`, [src/infra/infrastructure/services/conflation_service.pyL181-R185](diffhunk://#diff-ac85e2de12d6745329dc8e5daee9b19c892374adaf520c946a6cb4761f26eb72L181-R185))