### PR TITLE
'#42 Set curl as Azure transport option type in DuckDB context config'

### DIFF
--- a/src/infra/persistence/context/duckdb.py
+++ b/src/infra/persistence/context/duckdb.py
@@ -17,6 +17,7 @@ def create_duckdb_context() -> duckdb.DuckDBPyConnection:
     );
     """, [Config.BLOB_STORAGE_CONNECTION_STRING])
 
+    db_context.execute("SET azure_transport_option_type = curl")
     db_context.execute("SET azure_storage_connection_string = ?;", [Config.BLOB_STORAGE_CONNECTION_STRING])
 
     return db_context


### PR DESCRIPTION
This pull request introduces a minor but important configuration change to the DuckDB context setup. The main update is the explicit setting of the Azure transport option, which can help ensure compatibility and stability when connecting to Azure Blob Storage.

- Configuration update:
  * [`src/infra/persistence/context/duckdb.py`](diffhunk://#diff-b824b4fde4d3b50d2ad1043b51c61be62eb8bc03c16380fbc597eac8e7ef5130R20): Added a statement to set the `azure_transport_option_type` to `curl` in the DuckDB context creation function.