### PR TITLE
Refactor/46 update mit licence year

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ datasets/**/*.geojson
 datasets/**/*.parquet
 datasets/**/*.fgb
 *.parquet
+
+# Profiling
+profiling/**.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 KartAi
+Copyright (c) 2026 KartAi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request makes a minor update to the `LICENSE` file, updating the copyright year from 2025 to 2026.