### PR TITLE
Feature/67 simple blob storage db scan query

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,12 @@ services:
       context: .
       dockerfile: Dockerfile
     image: osm-pipeline:latest
-    command: python main.py
+    command: python main.py "conflation-pipeline"
+
+  blob_storage_db_scan:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: python main.py "blob-storage-db-scan"

--- a/main.py
+++ b/main.py
@@ -1,16 +1,35 @@
-﻿import uuid
+﻿import argparse
+import uuid
+from argparse import ArgumentError
 
 from src.application.common import monitor_cpu_and_ram
 from src.presentation.configuration import initialize_dependencies
-from src.presentation.entrypoints import run_pipeline
+from src.presentation.entrypoints import run_pipeline, blob_storage_db_scan
 
 RUN_ID = str(uuid.uuid4())
 
 
-@monitor_cpu_and_ram(run_id=RUN_ID, query_id="osm-fkb-conflation")
+@monitor_cpu_and_ram(run_id=RUN_ID, query_id="main")
 def main() -> None:
     initialize_dependencies()
-    run_pipeline()
+    script_id = get_script_id()
+
+    match script_id:
+        case "conflation-pipeline":
+            run_pipeline()
+            return
+        case "blob-storage-db-scan":
+            blob_storage_db_scan()
+            return
+        case _:
+            raise ArgumentError(argument=None, message="Script ID was invalid")
+
+
+def get_script_id() -> str:
+    parser = argparse.ArgumentParser("doppa-data")
+    parser.add_argument("id", help="ID of script to run")
+    args = parser.parse_args()
+    return args.id
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 ﻿import argparse
 import uuid
-from argparse import ArgumentError
 
 from src.application.common import monitor_cpu_and_ram
 from src.presentation.configuration import initialize_dependencies
@@ -22,7 +21,7 @@ def main() -> None:
             blob_storage_db_scan()
             return
         case _:
-            raise ArgumentError(argument=None, message="Script ID was invalid")
+            raise ValueError("Script ID is invalid")
 
 
 def get_script_id() -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -118,8 +118,8 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 python-json-logger==3.3.0
 pytz==2025.2
-pywin32==311
-pywinpty==3.0.0
+pywin32==311; sys_platform == "win32"
+pywinpty==3.0.0; sys_platform == "win32"
 PyYAML==6.0.3
 pyzmq==27.1.0
 rasterio==1.4.3

--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -88,7 +88,7 @@ def _sampler(
 
 
 def _initialize_threading(
-        target: Callable[[], object | None],
+        target: object | None,
         process: psutil.Process,
         samples: list[dict[str, Any]],
         initial_timestamp: float,

--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -13,7 +13,7 @@ from src.domain.enums import StorageContainer
 from src.infra.infrastructure import Containers
 
 
-def monitor_cpu_and_ram(run_id: str, query_id: str, interval: float = 0.05):
+def monitor_cpu_and_ram(run_id: str, query_id: str, interval: float = 0.00005):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):

--- a/src/presentation/configuration/app_config.py
+++ b/src/presentation/configuration/app_config.py
@@ -5,3 +5,4 @@ def initialize_dependencies() -> None:
     container = Containers()
     container.wire(modules=["src.application.common.monitor"])
     container.wire(modules=["src.presentation.entrypoints.release_pipeline"])
+    container.wire(modules=["src.presentation.entrypoints.blob_storage_db_scan"])

--- a/src/presentation/entrypoints/__init__.py
+++ b/src/presentation/entrypoints/__init__.py
@@ -1,1 +1,2 @@
 ﻿from .release_pipeline import run_pipeline
+from .blob_storage_db_scan import blob_storage_db_scan

--- a/src/presentation/entrypoints/blob_storage_db_scan.py
+++ b/src/presentation/entrypoints/blob_storage_db_scan.py
@@ -1,0 +1,24 @@
+﻿from dependency_injector.wiring import Provide, inject
+from duckdb import DuckDBPyConnection
+
+from src.application.contracts import IFilePathService
+from src.domain.enums import StorageContainer, Theme
+from src.infra.infrastructure import Containers
+
+
+@inject
+def blob_storage_db_scan(
+        db_context: DuckDBPyConnection = Provide[Containers.db_context],
+        path_service: IFilePathService = Provide[Containers.file_path_service]
+) -> None:
+    path = ""
+    path_service.create_virtual_filesystem_path(
+        storage_scheme="az",
+        release="2026-02-16.3",
+        container=StorageContainer.DATA,
+        theme=Theme.BUILDINGS,
+        region="*",
+        file_name="*.parquet"
+    )
+
+    db_context.execute(f"SELECT count(*) AS count FROM read_parquet('{path}')")

--- a/src/presentation/entrypoints/blob_storage_db_scan.py
+++ b/src/presentation/entrypoints/blob_storage_db_scan.py
@@ -11,8 +11,7 @@ def blob_storage_db_scan(
         db_context: DuckDBPyConnection = Provide[Containers.db_context],
         path_service: IFilePathService = Provide[Containers.file_path_service]
 ) -> None:
-    path = ""
-    path_service.create_virtual_filesystem_path(
+    path = path_service.create_virtual_filesystem_path(
         storage_scheme="az",
         release="2026-02-16.3",
         container=StorageContainer.DATA,


### PR DESCRIPTION
This pull request introduces a new entrypoint for running a blob storage database scan and refactors the way scripts are invoked via the command line. It also updates dependency injection wiring and makes a minor correction in threading initialization. The most important changes are grouped below:

**Entrypoint and Script Invocation Improvements:**

* Added a new entrypoint function `blob_storage_db_scan` in `src/presentation/entrypoints/blob_storage_db_scan.py`, which scans parquet files in blob storage using DuckDB and a virtual filesystem path service.
* Refactored `main.py` to use `argparse` for selecting which script to run (`conflation-pipeline` or `blob-storage-db-scan`), improving extensibility and error handling for script IDs.
* Updated the `docker-compose.yml` file to add a new service `blob_storage_db_scan` and changed the command for the main service to accept script IDs as arguments.

**Dependency Injection and Wiring:**

* Updated dependency injection wiring in `src/presentation/configuration/app_config.py` to include the new `blob_storage_db_scan` entrypoint.
* Added `blob_storage_db_scan` to the `__init__.py` of the entrypoints module for easier imports.

**Minor Technical Fixes:**

* Fixed the type annotation for the `target` parameter in `_initialize_threading` in `monitor.py` to accept `object | None` instead of a callable, aligning with how it's used.