### PR TITLE
Bugfix/77 fix bug where workflow is skipping on schedule

### DIFF
--- a/.github/workflows/publish-image-to-acr.yml
+++ b/.github/workflows/publish-image-to-acr.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build-and-push-queries:
     name: Build & Push Query ${{ matrix.display_name }}
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true  || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -57,7 +57,7 @@ jobs:
   build-and-push-container-orchestrator:
     name: Build & Push Container Orchestrator
     needs: build-and-push-queries
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -1,0 +1,56 @@
+﻿name: Run Benchmarks
+
+on:
+  workflow_run:
+    workflows: [ "Build and Push to Azure Container Registry" ]
+    types: [ completed ]
+  schedule:
+    - cron: "0 */3 * * *"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  run-benchmarks:
+    name: Run Benchmarks via Orchestrator
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'schedule'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'workflow_run'
+          && github.event.workflow_run.conclusion == 'success')
+
+    steps:
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Log in to ACR
+        uses: azure/docker-login@v2
+        with:
+          login-server: ${{ secrets.ACR_NAME }}.azurecr.io
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Pull Orchestrator from ACR
+        run: docker pull ${{ secrets.ACR_NAME }}.azurecr.io/container-orchestrator:latest
+
+      - name: Run Orchestrator Container
+        env:
+          ACR_LOGIN_SERVER: ${{ vars.ACR_LOGIN_SERVER }}
+          ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
+          ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
+          AZURE_BLOB_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_BLOB_STORAGE_CONNECTION_STRING }}
+        run: >
+          docker run --rm
+          -v "$HOME/.azure:/root/.azure"
+          -e ACR_LOGIN_SERVER
+          -e ACR_USERNAME
+          -e ACR_PASSWORD
+          -e AZURE_BLOB_STORAGE_CONNECTION_STRING
+          ${{ secrets.ACR_NAME }}.azurecr.io/container-orchestrator:latest


### PR DESCRIPTION
This pull request introduces a new benchmark workflow and expands the triggering conditions for existing container image publishing workflows. The main changes are grouped into workflow automation improvements and the addition of a new benchmarking workflow.

Workflow automation improvements:

* Updated the `build-and-push-queries` and `build-and-push-container-orchestrator` jobs in `.github/workflows/publish-image-to-acr.yml` to allow triggering on scheduled events (`github.event_name == 'schedule'`), enabling regular automated builds and pushes. [[1]](diffhunk://#diff-80870a328a6367d331c085d5ab143b3577f41c7f52e84c66ebb445941bebecd4L17-R17) [[2]](diffhunk://#diff-80870a328a6367d331c085d5ab143b3577f41c7f52e84c66ebb445941bebecd4L60-R60)

New benchmarking workflow:

* Added `.github/workflows/run-benchmarks.yml` to automate running benchmarks after successful container image builds, on a schedule (every 3 hours), or via manual dispatch. This workflow logs into Azure, pulls the orchestrator image from ACR, and runs the orchestrator container with necessary credentials and environment variables.