### PR TITLE
#77 Removed benchmark job from workflow and renamed file

### DIFF
--- a/.github/workflows/push-containers-to-acr.yml
+++ b/.github/workflows/push-containers-to-acr.yml
@@ -1,10 +1,8 @@
-name: Build and Push to Azure Container Registry
+name: Build and Push Query- and Orchestration-containers to Azure Container Registry
 
 on:
   pull_request:
     types: [ closed ]
-  schedule:
-    - cron: "0 */3 * * *"
   workflow_dispatch:
 
 permissions:
@@ -14,7 +12,7 @@ permissions:
 jobs:
   build-and-push-queries:
     name: Build & Push Query ${{ matrix.display_name }}
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true  || github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -57,7 +55,7 @@ jobs:
   build-and-push-container-orchestrator:
     name: Build & Push Container Orchestrator
     needs: build-and-push-queries
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true || github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
 
     steps:
@@ -85,38 +83,3 @@ jobs:
 
       - name: Push Container Orchestrator (commit SHA)
         run: docker push ${{ secrets.ACR_NAME }}.azurecr.io/container-orchestrator:${{ github.sha }}
-
-  run-benchmarks:
-    name: Run Benchmarks via Orchestrator
-    needs: build-and-push-container-orchestrator
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true || github.event_name == 'schedule' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Azure Login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Log in to ACR
-        uses: azure/docker-login@v2
-        with:
-          login-server: ${{ secrets.ACR_NAME }}.azurecr.io
-          username: ${{ secrets.ACR_USERNAME }}
-          password: ${{ secrets.ACR_PASSWORD }}
-
-      - name: Pull Orchestrator from ACR
-        run: docker pull ${{ secrets.ACR_NAME }}.azurecr.io/container-orchestrator:latest
-
-      - name: Run Orchestrator Container
-        env:
-          ACR_LOGIN_SERVER: ${{ vars.ACR_LOGIN_SERVER }}
-          ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
-          ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
-          AZURE_BLOB_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_BLOB_STORAGE_CONNECTION_STRING }}
-        run: docker run --rm -v "$HOME/.azure:/root/.azure" -e ACR_LOGIN_SERVER -e ACR_USERNAME -e ACR_PASSWORD -e AZURE_BLOB_STORAGE_CONNECTION_STRING ${{ secrets.ACR_NAME }}.azurecr.io/container-orchestrator:latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and pushing containers to Azure Container Registry. The main focus is on simplifying the workflow by removing scheduled and benchmark runs, and clarifying workflow naming and triggers.

Key changes:

**Workflow simplification and cleanup:**
* Removed the scheduled cron job trigger and all related conditional logic for scheduled runs from the workflow, so it now only triggers on pull request merges and manual dispatches. [[1]](diffhunk://#diff-467550af1a819846a650bd0db72e2caaa65c08abbae064fe85baa5e13867292eL1-L7) [[2]](diffhunk://#diff-467550af1a819846a650bd0db72e2caaa65c08abbae064fe85baa5e13867292eL17-R15) [[3]](diffhunk://#diff-467550af1a819846a650bd0db72e2caaa65c08abbae064fe85baa5e13867292eL60-R58)
* Deleted the entire `run-benchmarks` job, including all steps for running orchestrator benchmarks after container builds.

**Renaming and clarity:**
* Renamed the workflow file from `.github/workflows/publish-image-to-acr.yml` to `.github/workflows/push-containers-to-acr.yml`, and updated the workflow name to clarify it builds and pushes both query and orchestration containers.