### PR TITLE
#77 Changed workflow trigger name and schedule timer

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -2,10 +2,10 @@
 
 on:
   workflow_run:
-    workflows: [ "Build and Push to Azure Container Registry" ]
+    workflows: [ "Build and Push Query- and Orchestration-containers to Azure Container Registry" ]
     types: [ completed ]
   schedule:
-    - cron: "0 */3 * * *"
+    - cron: "*/10 * * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates the configuration for the benchmark workflow trigger in `.github/workflows/run-benchmarks.yml`. The main changes are to the workflow dependencies and the schedule frequency.

Workflow trigger updates:

* Changed the dependent workflow name from "Build and Push to Azure Container Registry" to "Build and Push Query- and Orchestration-containers to Azure Container Registry" to reflect the new workflow naming.

Scheduling changes:

* Increased the benchmark workflow run frequency by updating the cron schedule from every 3 hours to every 10 minutes.