### PR TITLE
Bugfix/82 run id is autogenerated for every run when running main method

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,14 +51,13 @@ def _delete_container_instance(container_group_name: str) -> None:
 
 
 def _create_container_instance(
+        run_id: str,
         experiment_id: str,
         container_group_name: str,
         docker_image: str,
         cpu: str,
         memory_gb: str,
 ) -> None:
-    run_id = _create_run_id()
-
     acr_login_server = os.getenv("ACR_LOGIN_SERVER")
     acr_username = os.getenv("ACR_USERNAME")
     acr_password = os.getenv("ACR_PASSWORD")
@@ -123,6 +122,8 @@ def main() -> None:
     with open(Config.BENCHMARK_FILE) as f:
         benchmark_configuration = yaml.safe_load(f)
 
+    run_id = _create_run_id()
+
     for experiment in benchmark_configuration["experiments"]:
         experiment_id = experiment["id"]
         container_group_name = f"benchmark-{experiment_id}"
@@ -134,6 +135,7 @@ def main() -> None:
 
         _delete_container_instance(container_group_name=container_group_name)
         _create_container_instance(
+            run_id=run_id,
             experiment_id=experiment_id,
             container_group_name=container_group_name,
             docker_image=docker_image,

--- a/main.py
+++ b/main.py
@@ -15,12 +15,9 @@ from src.application.common import logger
 
 def _create_run_id() -> str:
     date_prefix = date.today().isoformat()
-    random_suffix = ''.join(
-        random.SystemRandom().choice(string.ascii_uppercase + string.digits)
-        for _ in range(Config.RUN_ID_LENGTH)
-    )
+    suffix = "".join(random.choices(string.ascii_uppercase + string.digits, k=Config.RUN_ID_LENGTH))
 
-    return f"{date_prefix}-{random_suffix}"
+    return f"{date_prefix}-{suffix}"
 
 
 def _run_cmd(cmd: list[str]) -> str:

--- a/main.py
+++ b/main.py
@@ -86,7 +86,9 @@ def _create_container_instance(
 
     logger.info(f"Creating container group '{container_group_name}'...")
     _run_cmd(create_command)
-    logger.info(f"Created container group '{container_group_name}'")
+    logger.info(
+        f"Created container group '{container_group_name}' (CPU: {cpu} cores | RAM: {memory_gb} GB) with startup command '{startup_command}'"
+    )
 
 
 def _check_container_state(container_group_name: str, timeout: float = 5) -> None:

--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -12,6 +12,7 @@ import psutil
 from dependency_injector.wiring import Provide, inject
 
 from src import Config
+from src.application.common import logger
 from src.application.contracts import IMonitoringStorageService
 from src.infra.infrastructure import Containers
 
@@ -165,12 +166,15 @@ def _get_rss(process: psutil.Process) -> float:
 @inject
 def _get_run_id(run_id: str = Provide[Containers.config.run_id]) -> str:
     if run_id is not None:
+        logger.info(f"Found run ID '{run_id}' from DI.")
         return run_id
 
     today = date.today().strftime("%Y-%m-%d")
-    suffix = "".join(random.choices(string.ascii_uppercase + string.digits, k=6))
+    suffix = "".join(random.choices(string.ascii_uppercase + string.digits, k=Config.RUN_ID_LENGTH))
+    run_id = f"{today}-{suffix}"
+    logger.info(f"No run ID from DI. Created run ID '{run_id}'")
 
-    return f"{today}-{suffix}"
+    return run_id
 
 
 def _save_run(


### PR DESCRIPTION
This pull request introduces improvements to how run IDs are generated, passed, and logged throughout the application. It ensures that the `run_id` is created once and consistently propagated to container instances, and adds more informative logging for monitoring and debugging purposes.

**Run ID propagation and creation:**
- The `run_id` is now created once at the start of the `main()` function and passed explicitly to `_create_container_instance`, instead of being generated within the function itself. This ensures consistent run ID usage across all container instances. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R54-L61) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R125-R126) [[3]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R138)

**Logging improvements:**
- Added detailed logging in `_create_container_instance` to include CPU, RAM, and startup command information when a container group is created, improving traceability of resource allocation.
- Enhanced logging in the monitoring utility: now logs whether the `run_id` was found via dependency injection or generated, and logs the generated `run_id` with configurable suffix length.

**Imports:**
- Added import of `logger` in `src/application/common/monitor.py` to support new logging statements.