### PR TITLE
Feature/85 remove container deploy trigger from benchmarking workflow

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -13,11 +13,7 @@ jobs:
   run-benchmarks:
     name: Run Benchmarks via Orchestrator
     runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'schedule'
-      || github.event_name == 'workflow_dispatch'
-      || (github.event_name == 'workflow_run'
-          && github.event.workflow_run.conclusion == 'success')
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Azure Login

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -1,9 +1,6 @@
 name: Run Benchmarks
 
 on:
-  workflow_run:
-    workflows: [ "Build and Push Query- and Orchestration-containers to Azure Container Registry" ]
-    types: [ completed ]
   schedule:
     - cron: "*/10 * * * *"
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-﻿Add the following `.env` file
+﻿# doppa: A Framework for comparing traditional and cloud-native geospatial queries
+
+[![Build and Push Query- and Orchestration-containers to Azure Container Registry](https://github.com/kartAI/doppa-data/actions/workflows/push-containers-to-acr.yml/badge.svg)](https://github.com/kartAI/doppa-data/actions/workflows/push-containers-to-acr.yml) [![Run Benchmarks](https://github.com/kartAI/doppa-data/actions/workflows/run-benchmarks.yml/badge.svg?event=schedule)](https://github.com/kartAI/doppa-data/actions/workflows/run-benchmarks.yml)
+
+## Setup
+
+Add the following `.env` file
 
 ```dotenv
 AZURE_BLOB_STORAGE_CONNECTION_STRING=<azure-blob-storage-connection-string>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# doppa: A Framework for comparing traditional and cloud-native geospatial queries
+﻿# doppa: A Framework for Comparing Traditional & Cloud-Native Geospatial Queries
 
 [![Build and Push Query- and Orchestration-containers to Azure Container Registry](https://github.com/kartAI/doppa-data/actions/workflows/push-containers-to-acr.yml/badge.svg)](https://github.com/kartAI/doppa-data/actions/workflows/push-containers-to-acr.yml) [![Run Benchmarks](https://github.com/kartAI/doppa-data/actions/workflows/run-benchmarks.yml/badge.svg?event=schedule)](https://github.com/kartAI/doppa-data/actions/workflows/run-benchmarks.yml)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# doppa: A Framework for Comparing Traditional & Cloud-Native Geospatial Queries
+# doppa: A Framework for Comparing Traditional & Cloud-Native Geospatial Queries
 
 [![Build and Push Query- and Orchestration-containers to Azure Container Registry](https://github.com/kartAI/doppa-data/actions/workflows/push-containers-to-acr.yml/badge.svg)](https://github.com/kartAI/doppa-data/actions/workflows/push-containers-to-acr.yml) [![Run Benchmarks](https://github.com/kartAI/doppa-data/actions/workflows/run-benchmarks.yml/badge.svg?event=schedule)](https://github.com/kartAI/doppa-data/actions/workflows/run-benchmarks.yml)
 


### PR DESCRIPTION
This pull request updates the project documentation and modifies the benchmark workflow trigger to streamline CI/CD processes and clarify project setup. The most important changes are grouped below:

Documentation improvements:

* Added a project introduction and setup instructions to the `README.md`, including badges for build and benchmark workflow statuses to enhance visibility and clarify onboarding steps.

CI/CD workflow adjustments:

* Removed the `workflow_run` trigger from `.github/workflows/run-benchmarks.yml`, so benchmarks are now triggered only by a scheduled cron and manual dispatch, simplifying workflow execution.