### PR TITLE
#90 Updated DI path for db_scan_blob_storage.py

### DIFF
--- a/src/presentation/configuration/app_config.py
+++ b/src/presentation/configuration/app_config.py
@@ -8,7 +8,7 @@ def initialize_dependencies(run_id: str) -> None:
     container.wire(
         modules=[
             "src.application.common.monitor",
-            "src.presentation.entrypoints.blob_storage_db_scan",
+            "src.presentation.entrypoints.db_scan_blob_storage",
             "src.presentation.entrypoints.db_scan_postgis",
             "src.presentation.entrypoints.bbox_filtering",
             "src.presentation.entrypoints.setup_benchmarking_framework",


### PR DESCRIPTION
This pull request makes a minor update to the dependency injection configuration. It updates the module path for the blob storage database scan entrypoint to reflect a recent rename.

- Updated the module reference from `src.presentation.entrypoints.blob_storage_db_scan` to `src.presentation.entrypoints.db_scan_blob_storage` in the dependency injection wiring within `app_config.py`.