### PR TITLE
#82 Changed monitor query_id

### DIFF
--- a/src/presentation/entrypoints/db_scan_blob_storage.py
+++ b/src/presentation/entrypoints/db_scan_blob_storage.py
@@ -9,7 +9,7 @@ from src.infra.infrastructure import Containers
 
 
 @inject
-@monitor_cpu_and_ram(query_id="blob-storage-db-scan")
+@monitor_cpu_and_ram(query_id="db-scan-blob-storage")
 def db_scan_blob_storage(
         db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
         path_service: IFilePathService = Provide[Containers.file_path_service]


### PR DESCRIPTION
This pull request makes a minor update to the `db_scan_blob_storage` entrypoint by correcting the `query_id` parameter in the `@monitor_cpu_and_ram` decorator to use a more consistent naming convention.

- Changed the `query_id` in the `@monitor_cpu_and_ram` decorator from `"blob-storage-db-scan"` to `"db-scan-blob-storage"` in `src/presentation/entrypoints/db_scan_blob_storage.py` to improve naming consistency.