### PR TITLE
Feature/72 robust time measurement method

### DIFF
--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -68,11 +68,11 @@ def _sampler(
         thread_lock: threading.Lock,
         thread_event: threading.Event,
         samples: list[dict[str, Any]],
-        previous_timestamp: float,
-        previous_process_cpu_time: float,
         interval: float
 ) -> None:
     start_timestamp, start_process_cpu_time, start_system_cpu_time_per_core = _get_times(process)
+    previous_timestamp = start_timestamp
+    previous_process_cpu_time = start_process_cpu_time
 
     while not thread_event.wait(interval):
         try:
@@ -124,15 +124,11 @@ def _initialize_threading(
     thread_lock = threading.Lock()
     thread_event = threading.Event()
 
-    initial_timestamp, initial_process_cpu_time, _ = _get_times(process)
-
     kwargs = {
         "process": process,
         "thread_lock": thread_lock,
         "thread_event": thread_event,
         "samples": samples,
-        "previous_timestamp": initial_timestamp,
-        "previous_process_cpu_time": initial_process_cpu_time,
         "interval": interval
     }
 
@@ -146,11 +142,6 @@ def _initialize_cpu_metrics(process: psutil.Process) -> None:
     process.cpu_percent(interval=None)
     time.sleep(0.1)
     process.cpu_percent(interval=None)
-
-
-def _initialize_timers(process: psutil.Process) -> tuple[float, float]:
-    initial_timestamp, initial_cpu_time, _ = _get_times(process)
-    return initial_timestamp, initial_cpu_time
 
 
 def _get_times(process: psutil.Process) -> tuple[float, float, dict[int, dict[str, float]]]:

--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -23,6 +23,7 @@ def monitor_cpu_and_ram(query_id: str, interval: float = Config.DEFAULT_SAMPLE_T
         def wrapper(*args, **kwargs):
             result = None
             run_id = _get_run_id()
+            process = psutil.Process()
 
             logger.info(f"Starting benchmark for query '{query_id}' with run ID '{run_id}'.")
             logger.info(f"Executing {Config.BENCHMARK_WARMUP_RUNS} warmup runs.")
@@ -33,7 +34,6 @@ def monitor_cpu_and_ram(query_id: str, interval: float = Config.DEFAULT_SAMPLE_T
             logger.info(f"Benchmarking started with sampling interval of {interval} seconds.")
             for i in range(Config.BENCHMARK_RUNS):
                 iteration = i + 1
-                process = psutil.Process()
                 samples: list[dict[str, Any]] = []
 
                 _initialize_cpu_metrics(process=process)

--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -107,8 +107,8 @@ def _sampler(
 
             previous_timestamp = timestamp
             previous_process_cpu_time = process_cpu_time
-        except Exception:
-            pass
+        except Exception as e:
+            logger.error(f"Sampling error in _sampler: {e}")
 
 
 def _initialize_threading(

--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -54,7 +54,7 @@ def monitor_cpu_and_ram(query_id: str, interval: float = Config.DEFAULT_SAMPLE_T
 
                 _save_run(run_id=run_id, query_id=query_id, iteration=iteration, samples=samples)
 
-            logger.info(f"Benchmarking completed")
+            logger.info(f"Benchmarking completed.")
             _save_run_metadata(query_id=query_id, run_id=run_id)
             return result
 

--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -70,7 +70,7 @@ def _sampler(
         samples: list[dict[str, Any]],
         interval: float
 ) -> None:
-    start_timestamp, start_process_cpu_time, start_system_cpu_time_per_core = _get_times(process)
+    start_timestamp, start_process_cpu_time, _ = _get_times(process)
     previous_timestamp = start_timestamp
     previous_process_cpu_time = start_process_cpu_time
 

--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -72,7 +72,6 @@ def _sampler(
         previous_process_cpu_time: float,
         interval: float
 ) -> None:
-    cpu_count = _get_cpu_count()
     start_timestamp, start_process_cpu_time, start_system_cpu_time_per_core = _get_times(process)
 
     while not thread_event.wait(interval):
@@ -81,7 +80,6 @@ def _sampler(
             delta_process_cpu_time = process_cpu_time - previous_process_cpu_time
             elapsed_time = timestamp - previous_timestamp
 
-            # cpu_percent = (delta_process_cpu_time / elapsed_time) * 100.0 / cpu_count if elapsed_time > 0 else 0.0
             cpu_percent = process.cpu_percent()
             rss = _get_rss(process)
 

--- a/src/config.py
+++ b/src/config.py
@@ -72,7 +72,7 @@ class Config:
     BENCHMARK_FILE: Path = ROOT_DIR / "benchmarks.yml"
     RUN_ID_LENGTH: int = 6
     DEFAULT_SAMPLE_TIMEOUT: float = 0.00005
-    BENCHMARK_WARMUP_RUNS: int = 3
-    BENCHMARK_RUNS: int = 30
+    BENCHMARK_WARMUP_RUNS: int = 5
+    BENCHMARK_RUNS: int = 100
     BENCHMARK_METADATA_BLOB_NAME: str = "benchmark_metadata.parquet"
     BENCHMARK_DOPPA_DATA_RELEASE: str = "2026-02-16.3"

--- a/src/config.py
+++ b/src/config.py
@@ -71,7 +71,7 @@ class Config:
     # BENCHMARKING
     BENCHMARK_FILE: Path = ROOT_DIR / "benchmarks.yml"
     RUN_ID_LENGTH: int = 6
-    DEFAULT_SAMPLE_TIMEOUT: float = 0.00005
+    DEFAULT_SAMPLE_TIMEOUT: float = 0.05
     BENCHMARK_WARMUP_RUNS: int = 5
     BENCHMARK_RUNS: int = 100
     BENCHMARK_METADATA_BLOB_NAME: str = "benchmark_metadata.parquet"

--- a/src/config.py
+++ b/src/config.py
@@ -71,7 +71,7 @@ class Config:
     # BENCHMARKING
     BENCHMARK_FILE: Path = ROOT_DIR / "benchmarks.yml"
     RUN_ID_LENGTH: int = 6
-    DEFAULT_SAMPLE_TIMEOUT: float = 0.05
+    DEFAULT_SAMPLE_TIMEOUT: float = 0.001
     BENCHMARK_WARMUP_RUNS: int = 5
     BENCHMARK_RUNS: int = 100
     BENCHMARK_METADATA_BLOB_NAME: str = "benchmark_metadata.parquet"

--- a/src/infra/infrastructure/services/blob_storage_service.py
+++ b/src/infra/infrastructure/services/blob_storage_service.py
@@ -41,7 +41,7 @@ class BlobStorageService(IBlobStorageService):
             max_concurrency=Config.BLOB_STORAGE_MAX_CONCURRENCY
         )
 
-        logger.info(f"Uploaded blob '{blob_name}'. It can be accessed at: {blob_client.url}")
+        logger.debug(f"Uploaded blob '{blob_name}'. It can be accessed at: {blob_client.url}")
         return blob_client.url
 
     def delete_file(self) -> bool:


### PR DESCRIPTION
This pull request significantly enhances the benchmarking and monitoring logic in `src/application/common/monitor.py`, improves logging for clarity, and updates benchmarking configuration values in `src/config.py`. The main improvements include more detailed logging throughout the benchmarking process, changes to CPU metrics collection for greater accuracy, and updated benchmark run parameters for better performance measurement.

Benchmarking and Metrics Collection:

* Increased the number of warmup and benchmark runs in the `Config` class (`BENCHMARK_WARMUP_RUNS` from 3 to 5, `BENCHMARK_RUNS` from 30 to 100, and `DEFAULT_SAMPLE_TIMEOUT` from 0.00005 to 0.001) for more robust benchmarking results.
* Refactored CPU metrics sampling to use combined process CPU time and per-core system CPU times, improving the accuracy and granularity of collected metrics. Updated related functions and sample structure accordingly. [[1]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fL68-R111) [[2]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fL141-R177) [[3]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fL106-L108) [[4]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR129-R137)

Logging Enhancements:

* Added detailed logging for benchmark start, warmup, progress, completion, and metadata saving, providing clearer traceability for each benchmarking phase. [[1]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR27-L41) [[2]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR57) [[3]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR223) [[4]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR232-R233)
* Changed some log levels from `info` to `debug` for less critical operations, such as run ID and blob upload messages, to reduce log noise. [[1]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fL169-R192) [[2]](diffhunk://#diff-4d35f8bf6c8ee561266df5d4b6c4750fbe633c91e0bbd4b93bfe5bf2306ae408L44-R44)

These changes collectively make the benchmarking process more transparent, accurate, and configurable.