### PR TITLE
#102 Changed benchmarks to run at 03:30 every day

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -2,7 +2,7 @@ name: Run Benchmarks
 
 on:
   schedule:
-    - cron: "*/10 * * * *"
+    - cron: "30 3 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates the benchmark workflow schedule to run less frequently, moving from every 10 minutes to once daily at 3:30 AM.

* Workflow scheduling change:
  * [`.github/workflows/run-benchmarks.yml`](diffhunk://#diff-00107fb05307cc943b796fe04be904eaec8aaeacd416c00a9fc3d0ed281f25b7L5-R5): Updated the `cron` schedule for the `Run Benchmarks` workflow from every 10 minutes to once per day at 3:30 AM.