### PR TITLE
#102 Added check in dataframe to bytes converter

### DIFF
--- a/src/infra/infrastructure/services/bytes_service.py
+++ b/src/infra/infrastructure/services/bytes_service.py
@@ -4,6 +4,7 @@ import geopandas as gpd
 import pandas as pd
 from shapely import from_wkb
 
+from src.application.common import logger
 from src.application.contracts import IBytesService
 from src.domain.enums import EPSGCode
 
@@ -40,6 +41,9 @@ class BytesService(IBytesService):
 
     @staticmethod
     def convert_df_to_parquet_bytes(df: pd.DataFrame | gpd.GeoDataFrame) -> bytes:
+        if df.empty:
+            logger.warning("Converting empty DataFrame to bytes.")
+
         buffer = BytesIO()
         df.to_parquet(buffer, index=False)
         buffer.seek(0)


### PR DESCRIPTION
This pull request introduces logging to improve observability when converting empty DataFrames to Parquet bytes in the `bytes_service.py` file. The main change is the addition of a warning log message if an empty DataFrame is being converted, which will help with debugging and monitoring.

Logging improvements:

* Added a warning log using the `logger` from `src.application.common` when the `convert_df_to_parquet_bytes` method is called with an empty DataFrame.
* Imported the `logger` from `src.application.common` to enable logging within the service.