### PR TITLE
Feature/106 measure system cpu percentages for each logical core

### DIFF
--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -17,7 +17,7 @@ from src.application.contracts import IMonitoringStorageService
 from src.infra.infrastructure import Containers
 
 
-def monitor_cpu_and_ram(query_id: str, interval: float = Config.DEFAULT_SAMPLE_TIMEOUT):
+def monitor(query_id: str, interval: float = Config.DEFAULT_SAMPLE_TIMEOUT):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):

--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -140,8 +140,10 @@ def _initialize_threading(
 def _initialize_cpu_metrics(process: psutil.Process) -> None:
     # The initial `cpu_percent` returns a meaningless value. See 'https://psutil.readthedocs.io/en/latest/#psutil.cpu_percent' for more information
     process.cpu_percent(interval=None)
+    psutil.cpu_percent(percpu=True)
     time.sleep(0.1)
     process.cpu_percent(interval=None)
+    psutil.cpu_percent(percpu=True)
 
 
 def _get_cpu_metrics(process: psutil.Process) -> tuple[float, float, float, dict[int, dict[str, float]]]:

--- a/src/presentation/entrypoints/bbox_filtering.py
+++ b/src/presentation/entrypoints/bbox_filtering.py
@@ -1,14 +1,14 @@
 ﻿from dependency_injector.wiring import Provide, inject
 from duckdb import DuckDBPyConnection
 
-from src.application.common.monitor import monitor_cpu_and_ram
+from src.application.common.monitor import monitor
 from src.application.contracts import IFilePathService
 from src.domain.enums import StorageContainer, Theme
 from src.infra.infrastructure import Containers
 
 
 @inject
-@monitor_cpu_and_ram(query_id="duckdb-bbox-filtering")
+@monitor(query_id="duckdb-bbox-filtering")
 def duckdb_bbox_filtering(
         db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
         path_service: IFilePathService = Provide[Containers.file_path_service],

--- a/src/presentation/entrypoints/db_scan_blob_storage.py
+++ b/src/presentation/entrypoints/db_scan_blob_storage.py
@@ -2,14 +2,14 @@
 from duckdb import DuckDBPyConnection
 
 from src import Config
-from src.application.common.monitor import monitor_cpu_and_ram
+from src.application.common.monitor import monitor
 from src.application.contracts import IFilePathService
 from src.domain.enums import StorageContainer, Theme
 from src.infra.infrastructure import Containers
 
 
 @inject
-@monitor_cpu_and_ram(query_id="db-scan-blob-storage")
+@monitor(query_id="db-scan-blob-storage")
 def db_scan_blob_storage(
         db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
         path_service: IFilePathService = Provide[Containers.file_path_service]

--- a/src/presentation/entrypoints/db_scan_postgis.py
+++ b/src/presentation/entrypoints/db_scan_postgis.py
@@ -1,12 +1,12 @@
 ﻿from dependency_injector.wiring import inject, Provide
 from sqlalchemy import Engine, text
 
-from src.application.common.monitor import monitor_cpu_and_ram
+from src.application.common.monitor import monitor
 from src.infra.infrastructure import Containers
 
 
 @inject
-@monitor_cpu_and_ram(query_id="db-scan-postgis")
+@monitor(query_id="db-scan-postgis")
 def db_scan_postgis(
         db_context: Engine = Provide[Containers.postgres_context]
 ) -> None:


### PR DESCRIPTION
This pull request refactors and enhances the CPU and RAM monitoring utilities in the application. The main focus is on generalizing the monitoring decorator, improving the accuracy and richness of CPU metrics collected (including per-core usage percentages), and updating all entrypoints to use the new monitoring interface.

**Monitoring utility improvements:**

* Renamed the monitoring decorator from `monitor_cpu_and_ram` to a more general `monitor`, and updated all usages in entrypoint files to use the new name. [[1]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fL20-R20) [[2]](diffhunk://#diff-2c98042ca81404571ee12bd21e32443abe90e70226f0e451e1e6a212eab0996cL4-R11) [[3]](diffhunk://#diff-196159f3fc78bfbfa5b1dc74231a91c2acc8dd9cce7a7615d5ab730663454dacL5-R12) [[4]](diffhunk://#diff-77d680b08c333dae7ac98518eb99f096d8bc85e429c0c05908a2b98b319747ebL4-R9)

* Refactored the internal CPU metrics collection:
  - Replaced `_get_times` with `_get_cpu_metrics`, which now also returns overall and per-core CPU usage percentages.
  - Updated the sampling logic in `_sampler` to use the new metrics, and to include per-core CPU usage percentages in the collected data. [[1]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fL73-R92) [[2]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fL147-R160) [[3]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fL166-R171)

These changes make the monitoring more flexible and provide richer data for performance analysis.