### PR TITLE
Feature/98 skip benchmark runs if one is already running

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -5,11 +5,46 @@ on:
     - cron: "30 3 * * *"
   workflow_dispatch:
 
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.ref }}
+#  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: read
 
 jobs:
+  check-concurrency:
+    name: Check if another run is in progress
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+
+    steps:
+      - name: Check for in-progress runs
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: context.workflow,
+              branch: context.ref.replace('refs/heads/', ''),
+              status: 'in_progress',
+              per_page: 50,
+            });
+            
+            // Exclude the current run from the check
+            const otherInProgress = runs.data.workflow_runs
+              .filter(r => r.id !== context.runId);
+            
+            const shouldRun = otherInProgress.length === 0;
+            core.info(`Other in-progress runs: ${otherInProgress.length}`);
+            core.setOutput('should_run', shouldRun ? 'true' : 'false');
+
   run-benchmarks:
     name: Run Benchmarks via Orchestrator
     runs-on: ubuntu-latest

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -5,46 +5,15 @@ on:
     - cron: "30 3 * * *"
   workflow_dispatch:
 
-#concurrency:
-#  group: ${{ github.workflow }}-${{ github.ref }}
-#  cancel-in-progress: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  check-concurrency:
-    name: Check if another run is in progress
-    runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.check.outputs.should_run }}
-
-    steps:
-      - name: Check for in-progress runs
-        id: check
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            
-            const runs = await github.rest.actions.listWorkflowRuns({
-              owner,
-              repo,
-              workflow_id: context.workflow,
-              branch: context.ref.replace('refs/heads/', ''),
-              status: 'in_progress',
-              per_page: 50,
-            });
-            
-            // Exclude the current run from the check
-            const otherInProgress = runs.data.workflow_runs
-              .filter(r => r.id !== context.runId);
-            
-            const shouldRun = otherInProgress.length === 0;
-            core.info(`Other in-progress runs: ${otherInProgress.length}`);
-            core.setOutput('should_run', shouldRun ? 'true' : 'false');
-
   run-benchmarks:
     name: Run Benchmarks via Orchestrator
     runs-on: ubuntu-latest

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   id-token: write


### PR DESCRIPTION
This pull request introduces a configuration update to the GitHub Actions workflow for running benchmarks. The main change is the addition of a concurrency group to control how workflow runs are managed.

Workflow configuration improvements:

* Added a `concurrency` group to `.github/workflows/run-benchmarks.yml` to ensure that multiple runs of the same workflow on the same branch are grouped together, preventing duplicate runs from overlapping. The `cancel-in-progress` option is set to `false`, so in-progress runs are not canceled when a new run is triggered.