### PR TITLE
Feature/115 postgis bounding box filtering

### DIFF
--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -33,7 +33,7 @@ jobs:
         run: python -m compileall src main.py benchmark_runner.py
 
   build-docker-images:
-    name: Build Docker Images – ${{ matrix.display_name }}
+    name: Build ${{ matrix.display_name }}
     runs-on: ubuntu-latest
 
     needs:
@@ -54,6 +54,9 @@ jobs:
 
           - service: bbox-filtering-advanced-duckdb
             display_name: Advanced DuckDB Bounding Box Filtering
+
+          - service: bbox-filtering-advanced-postgis
+            display_name: Advanced PostGIS Bounding Box Filtering
 
     steps:
       - name: Checkout code

--- a/.github/workflows/push-containers-to-acr.yml
+++ b/.github/workflows/push-containers-to-acr.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build-and-push-queries:
-    name: Build & Push Query ${{ matrix.display_name }}
+    name: Build & Push ${{ matrix.display_name }}
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
 
@@ -33,6 +33,10 @@ jobs:
           - service: bbox-filtering-advanced-duckdb
             image: bbox-filtering-advanced-duckdb
             display_name: Advanced DuckDB Bounding Box Filtering
+
+          - service: bbox-filtering-advanced-postgis
+            image: bbox-filtering-advanced-postgis
+            display_name: Advanced PostGIS Bounding Box Filtering
 
     steps:
       - name: Checkout code

--- a/benchmark_runner.py
+++ b/benchmark_runner.py
@@ -3,7 +3,8 @@ from typing import Optional
 
 from src.presentation.configuration import initialize_dependencies
 from src.presentation.entrypoints import (
-    db_scan_blob_storage, duckdb_bbox_filtering, db_scan_postgis, setup_benchmarking_framework
+    db_scan_blob_storage, duckdb_bbox_filtering, db_scan_postgis, setup_benchmarking_framework,
+    bbox_filtering_advanced_postgis
 )
 
 
@@ -20,6 +21,9 @@ def benchmark_runner() -> None:
             return
         case "duckdb-bbox-filtering":
             duckdb_bbox_filtering()
+            return
+        case "bbox-filtering-advanced-postgis":
+            bbox_filtering_advanced_postgis()
             return
         case "setup-framework":
             setup_benchmarking_framework()

--- a/benchmark_runner.py
+++ b/benchmark_runner.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 from src.presentation.configuration import initialize_dependencies
 from src.presentation.entrypoints import (
-    db_scan_blob_storage, duckdb_bbox_filtering, db_scan_postgis, setup_benchmarking_framework,
-    bbox_filtering_advanced_postgis
+    db_scan_blob_storage, db_scan_postgis, setup_benchmarking_framework, bbox_filtering_advanced_postgis,
+    bbox_filtering_advanced_duckdb
 )
 
 
@@ -19,8 +19,8 @@ def benchmark_runner() -> None:
         case "db-scan-postgis":
             db_scan_postgis()
             return
-        case "duckdb-bbox-filtering":
-            duckdb_bbox_filtering()
+        case "bbox-filtering-advanced-duckdb":
+            bbox_filtering_advanced_duckdb()
             return
         case "bbox-filtering-advanced-postgis":
             bbox_filtering_advanced_postgis()

--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -9,7 +9,12 @@ experiments:
     cpu: 4
     memory_gb: 16
 
-  - id: duckdb-bbox-filtering
-    image: doppaacr.azurecr.io/duckdb-bbox-filtering:latest
+  - id: bbox-filtering-advanced-duckdb
+    image: doppaacr.azurecr.io/bbox-filtering-advanced-duckdb:latest
+    cpu: 4
+    memory_gb: 16
+
+  - id: bbox-filtering-advanced-postgis
+    image: doppaacr.azurecr.io/bbox-filtering-advanced-postgis:latest
     cpu: 4
     memory_gb: 16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,3 +34,12 @@ services:
       dockerfile: .docker/Query.Dockerfile
     image: bbox-filtering-advanced-duckdb:latest
     command: python benchmark_runner.py --script-id bbox-filtering-advanced-duckdb
+
+  bbox-filtering-advanced-postgis:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: bbox-filtering-advanced-postgis:latest
+    command: python benchmark_runner.py --script-id bbox-filtering-advanced-postgis

--- a/src/presentation/configuration/app_config.py
+++ b/src/presentation/configuration/app_config.py
@@ -13,6 +13,7 @@ def initialize_dependencies(run_id: str, benchmark_run: int) -> None:
             "src.presentation.entrypoints.db_scan_blob_storage",
             "src.presentation.entrypoints.db_scan_postgis",
             "src.presentation.entrypoints.bbox_filtering_advanced_duckdb",
+            "src.presentation.entrypoints.bbox_filtering_advanced_postgis",
             "src.presentation.entrypoints.setup_benchmarking_framework",
         ]
     )

--- a/src/presentation/entrypoints/__init__.py
+++ b/src/presentation/entrypoints/__init__.py
@@ -2,4 +2,5 @@
 from .db_scan_blob_storage import db_scan_blob_storage
 from .db_scan_postgis import db_scan_postgis
 from .bbox_filtering import duckdb_bbox_filtering
+from .bbox_filtering_advanced_postgis import bbox_filtering_advanced_postgis
 from .setup_benchmarking_framework import setup_benchmarking_framework

--- a/src/presentation/entrypoints/__init__.py
+++ b/src/presentation/entrypoints/__init__.py
@@ -1,6 +1,6 @@
 ﻿from .release_pipeline import run_pipeline
 from .db_scan_blob_storage import db_scan_blob_storage
 from .db_scan_postgis import db_scan_postgis
-from .bbox_filtering import duckdb_bbox_filtering
+from .bbox_filtering_advanced_duckdb import bbox_filtering_advanced_duckdb
 from .bbox_filtering_advanced_postgis import bbox_filtering_advanced_postgis
 from .setup_benchmarking_framework import setup_benchmarking_framework

--- a/src/presentation/entrypoints/bbox_filtering_advanced_duckdb.py
+++ b/src/presentation/entrypoints/bbox_filtering_advanced_duckdb.py
@@ -8,7 +8,7 @@ from src.infra.infrastructure import Containers
 
 
 @inject
-@monitor(query_id="bbox-filtering-advanced-duckdb")
+@monitor(query_id="bbox-filtering-advanced-duckdb", interval=0.01)
 def bbox_filtering_advanced_duckdb(
         db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
         path_service: IFilePathService = Provide[Containers.file_path_service],

--- a/src/presentation/entrypoints/bbox_filtering_advanced_duckdb.py
+++ b/src/presentation/entrypoints/bbox_filtering_advanced_duckdb.py
@@ -8,8 +8,8 @@ from src.infra.infrastructure import Containers
 
 
 @inject
-@monitor(query_id="duckdb-bbox-filtering")
-def duckdb_bbox_filtering(
+@monitor(query_id="bbox-filtering-advanced-duckdb")
+def bbox_filtering_advanced_duckdb(
         db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
         path_service: IFilePathService = Provide[Containers.file_path_service],
 ) -> None:

--- a/src/presentation/entrypoints/bbox_filtering_advanced_postgis.py
+++ b/src/presentation/entrypoints/bbox_filtering_advanced_postgis.py
@@ -1,0 +1,13 @@
+﻿from dependency_injector.wiring import Provide, inject
+from sqlalchemy import Engine
+
+from src.application.common.monitor import monitor
+from src.infra.infrastructure import Containers
+
+
+@inject
+@monitor(query_id="bbox-filtering-advanced-postgis")
+def bbox_filtering_advanced_postgis(
+        db_context: Engine = Provide[Containers.postgres_context]
+) -> None:
+    pass

--- a/src/presentation/entrypoints/bbox_filtering_advanced_postgis.py
+++ b/src/presentation/entrypoints/bbox_filtering_advanced_postgis.py
@@ -1,13 +1,60 @@
 ﻿from dependency_injector.wiring import Provide, inject
-from sqlalchemy import Engine
+from sqlalchemy import Engine, text
 
 from src.application.common.monitor import monitor
 from src.infra.infrastructure import Containers
 
 
 @inject
-@monitor(query_id="bbox-filtering-advanced-postgis")
+@monitor(query_id="bbox-filtering-advanced-postgis", interval=0.01)
 def bbox_filtering_advanced_postgis(
-        db_context: Engine = Provide[Containers.postgres_context]
+        db_context: Engine = Provide[Containers.postgres_context],
 ) -> None:
-    pass
+    # Same bbox as in the DuckDB example (Oslo-ish, WGS84 lon/lat)
+    min_lon = 10.40
+    max_lon = 10.95
+    min_lat = 59.70
+    max_lat = 60.10
+
+    sql = text(
+        """
+        WITH src AS (SELECT *, geometry AS geom_4326 FROM buildings),
+             bbox AS (
+                 -- Axis-aligned bbox in EPSG:4326 (lon/lat)
+                 SELECT ST_MakeEnvelope(
+                                :min_lon,
+                                :min_lat,
+                                :max_lon,
+                                :max_lat,
+                                4326
+                        ) AS bbox_4326),
+             filtered AS (
+                 -- Subselect so we can reference geom_25833 in the outer WHERE
+                 SELECT *
+                 FROM (SELECT s.*,
+                              ST_Transform(s.geom_4326, 25833) AS geom_25833
+                       FROM src s
+                                CROSS JOIN bbox b
+                       WHERE ST_Intersects(s.geom_4326, b.bbox_4326)
+                         AND ST_IsValid(s.geom_4326)) t
+                 WHERE
+                     -- Advanced: realistic building area in EPSG:25833 (ETRS89 / UTM 33N)
+                     ST_Area(geom_25833) BETWEEN 50 AND 5000)
+        SELECT COUNT(*)                      AS building_count,
+               AVG(ST_Area(geom_25833))      AS avg_area_m2,
+               MIN(ST_Perimeter(geom_25833)) AS min_perimeter_m,
+               MAX(ST_Perimeter(geom_25833)) AS max_perimeter_m
+        FROM filtered;
+        """
+    )
+
+    with db_context.connect() as conn:
+        _ = conn.execute(
+            sql,
+            {
+                "min_lon": min_lon,
+                "min_lat": min_lat,
+                "max_lon": max_lon,
+                "max_lat": max_lat,
+            },
+        ).fetchone()


### PR DESCRIPTION
This pull request introduces a new advanced PostGIS-based bounding box filtering benchmark, aligns naming conventions for advanced filtering benchmarks, and updates workflow and configuration files to support these changes. The main themes are the addition of the new benchmark, updates to Docker and workflow configurations, and codebase refactoring for clarity and consistency.

**New advanced PostGIS bounding box filtering benchmark:**

* Added a new entrypoint `bbox_filtering_advanced_postgis` in `src/presentation/entrypoints/bbox_filtering_advanced_postgis.py`, which performs advanced bounding box filtering using PostGIS and includes realistic area and perimeter calculations.
* Registered `bbox_filtering_advanced_postgis` in the dependency injection configuration in `src/presentation/configuration/app_config.py`.
* Included `bbox_filtering_advanced_postgis` in the entrypoints module export in `src/presentation/entrypoints/__init__.py`.
* Updated the benchmark runner in `benchmark_runner.py` to support the new script ID and function for `bbox-filtering-advanced-postgis`. [[1]](diffhunk://#diff-56f497f357c1a86b3152b78bc93c915029e06e2021f9a1b2ca20caf80a1823d8L6-R7) [[2]](diffhunk://#diff-56f497f357c1a86b3152b78bc93c915029e06e2021f9a1b2ca20caf80a1823d8L21-R26)
* Added a new service for `bbox-filtering-advanced-postgis` in `docker-compose.yml` with appropriate build and run commands.
* Added a new experiment configuration for `bbox-filtering-advanced-postgis` in `benchmarks.yml`.
* Updated GitHub Actions workflows to build and push the new PostGIS benchmark container (`.github/workflows/pull-request-tests.yml`, `.github/workflows/push-containers-to-acr.yml`). [[1]](diffhunk://#diff-972ccf921ef50999f7079000c7da03cb645fa38e4eec71ea20fb9915d187b13fR58-R60) [[2]](diffhunk://#diff-467550af1a819846a650bd0db72e2caaa65c08abbae064fe85baa5e13867292eR37-R40)

**Refactoring and naming consistency:**

* Renamed the DuckDB filtering entrypoint and related references from `duckdb_bbox_filtering` to `bbox_filtering_advanced_duckdb` for consistency with the new PostGIS benchmark. [[1]](diffhunk://#diff-9c015ddeac1ef1ac033e012fef2cc245f8b4c42f6555e62e18661b241e6c3384L11-R12) [[2]](diffhunk://#diff-6293be55b065b6daf5745e1fc2f35b20f6c419f2ba5ec92e523c78916ec2b2f0L4-R5) [[3]](diffhunk://#diff-56f497f357c1a86b3152b78bc93c915029e06e2021f9a1b2ca20caf80a1823d8L6-R7) [[4]](diffhunk://#diff-56f497f357c1a86b3152b78bc93c915029e06e2021f9a1b2ca20caf80a1823d8L21-R26)
* Updated experiment, service, and workflow names to use the new `bbox-filtering-advanced-duckdb` naming convention. [[1]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L12-R18) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R37-R45) [[3]](diffhunk://#diff-972ccf921ef50999f7079000c7da03cb645fa38e4eec71ea20fb9915d187b13fR58-R60) [[4]](diffhunk://#diff-467550af1a819846a650bd0db72e2caaa65c08abbae064fe85baa5e13867292eR37-R40)

**Workflow and metadata improvements:**

* Simplified and clarified job names in GitHub Actions workflows for both building and pushing containers. (`.github/workflows/pull-request-tests.yml`, `.github/workflows/push-containers-to-acr.yml`) [[1]](diffhunk://#diff-972ccf921ef50999f7079000c7da03cb645fa38e4eec71ea20fb9915d187b13fL36-R36) [[2]](diffhunk://#diff-467550af1a819846a650bd0db72e2caaa65c08abbae064fe85baa5e13867292eL18-R18)

These changes ensure that both advanced DuckDB and PostGIS bounding box filtering benchmarks are available, consistently named, and properly integrated into the build, test, and deployment pipelines.