### PR TITLE
Feature/121 parquet vs shapefile

### DIFF
--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -58,6 +58,12 @@ jobs:
           - service: bbox-filtering-advanced-postgis
             display_name: Advanced PostGIS Bounding Box Filtering
 
+          - service: bbox-filtering-simple-local
+            display_name: Simple Shapefile + Shapefile Bounding Box Filtering
+
+          - service: bbox-filtering-simple-blob-storage
+            display_name: Simple GeoParquet + Shapefile Bounding Box Filtering
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -59,10 +59,10 @@ jobs:
             display_name: Advanced PostGIS Bounding Box Filtering
 
           - service: bbox-filtering-simple-local
-            display_name: Simple Shapefile + Shapefile Bounding Box Filtering
+            display_name: Simple Shapefile Bounding Box Filtering
 
           - service: bbox-filtering-simple-blob-storage
-            display_name: Simple GeoParquet + Shapefile Bounding Box Filtering
+            display_name: Simple GeoParquet Bounding Box Filtering
 
     steps:
       - name: Checkout code

--- a/.github/workflows/push-containers-to-acr.yml
+++ b/.github/workflows/push-containers-to-acr.yml
@@ -40,11 +40,11 @@ jobs:
 
           - service: bbox-filtering-simple-local
             image: bbox-filtering-simple-local
-            display_name: Simple Shapefile + Shapefile Bounding Box Filtering
+            display_name: Simple Shapefile Bounding Box Filtering
 
           - service: bbox-filtering-simple-blob-storage
             image: bbox-filtering-simple-blob-storage
-            display_name: Simple GeoParquet + Shapefile Bounding Box Filtering
+            display_name: Simple GeoParquet Bounding Box Filtering
 
     steps:
       - name: Checkout code

--- a/.github/workflows/push-containers-to-acr.yml
+++ b/.github/workflows/push-containers-to-acr.yml
@@ -38,6 +38,14 @@ jobs:
             image: bbox-filtering-advanced-postgis
             display_name: Advanced PostGIS Bounding Box Filtering
 
+          - service: bbox-filtering-simple-local
+            image: bbox-filtering-simple-local
+            display_name: Simple Shapefile + Shapefile Bounding Box Filtering
+
+          - service: bbox-filtering-simple-blob-storage
+            image: bbox-filtering-simple-blob-storage
+            display_name: Simple GeoParquet + Shapefile Bounding Box Filtering
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -211,6 +211,8 @@ datasets/**/*.fgb
 *.parquet
 monitor_logs/**/*.csv
 monitor_logs/**/*.parquet
+resources/*
+!resources/.gitkeep
 
 # Profiling
 profiling/**.json

--- a/benchmark_runner.py
+++ b/benchmark_runner.py
@@ -4,7 +4,7 @@ from typing import Optional
 from src.presentation.configuration import initialize_dependencies
 from src.presentation.entrypoints import (
     db_scan_blob_storage, db_scan_postgis, setup_benchmarking_framework, bbox_filtering_advanced_postgis,
-    bbox_filtering_advanced_duckdb
+    bbox_filtering_advanced_duckdb, bbox_filtering_simple_local, bbox_filtering_simple_blob_storage
 )
 
 
@@ -24,6 +24,12 @@ def benchmark_runner() -> None:
             return
         case "bbox-filtering-advanced-postgis":
             bbox_filtering_advanced_postgis()
+            return
+        case "bbox-filtering-simple-local":
+            bbox_filtering_simple_local()
+            return
+        case "bbox-filtering-simple-blob-storage":
+            bbox_filtering_simple_blob_storage()
             return
         case "setup-framework":
             setup_benchmarking_framework()

--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -18,3 +18,13 @@ experiments:
     image: doppaacr.azurecr.io/bbox-filtering-advanced-postgis:latest
     cpu: 4
     memory_gb: 16
+
+  - id: bbox-filtering-simple-local
+    image: doppaacr.azurecr.io/bbox-filtering-simple-local:latest
+    cpu: 4
+    memory_gb: 16
+
+  - id: bbox-filtering-simple-blob-storage
+    image: doppaacr.azurecr.io/bbox-filtering-simple-blob-storage:latest
+    cpu: 4
+    memory_gb: 16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,3 +43,21 @@ services:
       dockerfile: .docker/Query.Dockerfile
     image: bbox-filtering-advanced-postgis:latest
     command: python benchmark_runner.py --script-id bbox-filtering-advanced-postgis
+
+  bbox-filtering-simple-local:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: bbox-filtering-simple-local:latest
+    command: python benchmark_runner.py --script-id bbox-filtering-simple-local
+
+  bbox-filtering-simple-blob-storage:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: bbox-filtering-simple-blob-storage:latest
+    command: python benchmark_runner.py --script-id bbox-filtering-simple-blob-storage

--- a/src/application/contracts/__init__.py
+++ b/src/application/contracts/__init__.py
@@ -1,4 +1,5 @@
-﻿from .blob_storage_service_interface import IBlobStorageService
+﻿from .benchmark_service_interface import IBenchmarkService
+from .blob_storage_service_interface import IBlobStorageService
 from .open_street_map_file_service_interface import IOpenStreetMapFileService
 from .open_street_map_service_interface import IOpenStreetMapService
 from .file_path_service_interface import IFilePathService

--- a/src/application/contracts/benchmark_service_interface.py
+++ b/src/application/contracts/benchmark_service_interface.py
@@ -1,13 +1,14 @@
 ﻿from abc import ABC, abstractmethod
+from pathlib import Path
 
 
 class IBenchmarkService(ABC):
     @abstractmethod
-    def download_parquet_as_shapefile_locally(self, azure_virtual_file_path: str, save_path: str) -> None:
+    def download_parquet_as_shapefile_locally(self, virtual_file_path: str, save_path: Path) -> None:
         """
         Download the parquet files from blob storage and save them locally as shapefiles. This is intended for use
         BEFORE the benchmarking.
-        :param azure_virtual_file_path: The virtual file path in blob storage where the parquet files are stored.
+        :param virtual_file_path: The virtual file path in blob storage where the parquet files are stored.
         :param save_path: The local path where the shapefiles will be saved.
         :return: None
         """

--- a/src/application/contracts/benchmark_service_interface.py
+++ b/src/application/contracts/benchmark_service_interface.py
@@ -1,0 +1,14 @@
+﻿from abc import ABC, abstractmethod
+
+
+class IBenchmarkService(ABC):
+    @abstractmethod
+    def download_parquet_as_shapefile_locally(self, azure_virtual_file_path: str, save_path: str) -> None:
+        """
+        Download the parquet files from blob storage and save them locally as shapefiles. This is intended for use
+        BEFORE the benchmarking.
+        :param azure_virtual_file_path: The virtual file path in blob storage where the parquet files are stored.
+        :param save_path: The local path where the shapefiles will be saved.
+        :return: None
+        """
+        raise NotImplementedError

--- a/src/config.py
+++ b/src/config.py
@@ -32,6 +32,7 @@ class Config:
     # DIRECTORIES
     ROOT_DIR: Path = Path.cwd() if not IS_NOTEBOOK else Path.cwd().parent.parent.parent
     LOG_DIR: Path = ROOT_DIR / f"logs"
+    BUILDINGS_SHAPEFILE: Path = ROOT_DIR / "resources" / "buildings.shp"
 
     # LOGGING
     LOGGING_LEVEL: int = logging.INFO

--- a/src/config.py
+++ b/src/config.py
@@ -72,7 +72,7 @@ class Config:
     # BENCHMARKING
     BENCHMARK_FILE: Path = ROOT_DIR / "benchmarks.yml"
     RUN_ID_LENGTH: int = 6
-    DEFAULT_SAMPLE_TIMEOUT: float = 0.001
+    DEFAULT_SAMPLE_TIMEOUT: float = 0.01
     BENCHMARK_RUNS: int = 5
     BENCHMARK_WARMUP_ITERATIONS: int = 5
     BENCHMARK_ITERATIONS: int = 100

--- a/src/infra/infrastructure/containers.py
+++ b/src/infra/infrastructure/containers.py
@@ -6,6 +6,7 @@ from src.infra.infrastructure.services import (
     CountyService, VectorService, StacService, StacIOService, FKBService, ZipService, FKBFileService, ConflationService,
     MonitoringStorageService
 )
+from src.infra.infrastructure.services.benchmark_service import BenchmarkService
 from src.infra.persistence.context import create_duckdb_context, create_blob_storage_context, create_postgres_db_context
 
 
@@ -99,6 +100,11 @@ class Containers(containers.DeclarativeContainer):
         blob_storage_service=blob_storage_service,
         bytes_service=bytes_service,
         file_path_service=file_path_service
+    )
+
+    benchmark_service = providers.Singleton(
+        BenchmarkService,
+        duckdb_context=duckdb_context
     )
 
     StacIO.set_default(stac_io_service)

--- a/src/infra/infrastructure/services/benchmark_service.py
+++ b/src/infra/infrastructure/services/benchmark_service.py
@@ -31,7 +31,7 @@ class BenchmarkService(IBenchmarkService):
                 bbox.xmin AS bbox_xmin,
                 bbox.ymax AS bbox_ymax,
                 bbox.ymin AS bbox_ymin
-            FROM read_parquet('{virtual_file_path}') LIMIT 100;
+            FROM read_parquet('{virtual_file_path}');
 
             COPY (
                 SELECT

--- a/src/infra/infrastructure/services/benchmark_service.py
+++ b/src/infra/infrastructure/services/benchmark_service.py
@@ -14,16 +14,33 @@ class BenchmarkService(IBenchmarkService):
     def download_parquet_as_shapefile_locally(self, virtual_file_path: str, save_path: Path) -> None:
         save_path.parent.mkdir(parents=True, exist_ok=True)
 
+        base = save_path.with_suffix("")
+        for ext in (".shp", ".shx", ".dbf", ".prj", ".cpg"):
+            candidate = base.with_suffix(ext)
+            candidate.unlink(missing_ok=True)
+
         self.__duckdb_context.execute(
             f"""
-            CREATE TABLE buildings AS SELECT * FROM read_parquet('{virtual_file_path}');
-            
+            CREATE  TABLE buildings AS SELECT
+                *,
+                bbox.maxx AS bbox_maxx,
+                bbox.maxy AS bbox_maxy,
+                bbox.minx AS bbox_minx,
+                bbox.miny AS bbox_miny,
+                bbox.xmax AS bbox_xmax,
+                bbox.xmin AS bbox_xmin,
+                bbox.ymax AS bbox_ymax,
+                bbox.ymin AS bbox_ymin
+            FROM read_parquet('{virtual_file_path}') LIMIT 100;
+
             COPY (
-                SELECT * FROM buildings
-            ) TO '{str(save_path)}'
+                SELECT
+                    * EXCLUDE (bbox)
+                FROM buildings
+            ) TO '{save_path.as_posix()}'
             WITH (
                 FORMAT GDAL,
                 DRIVER 'ESRI Shapefile'
-            )
+            );
             """
         )

--- a/src/infra/infrastructure/services/benchmark_service.py
+++ b/src/infra/infrastructure/services/benchmark_service.py
@@ -1,4 +1,6 @@
-﻿import duckdb
+﻿from pathlib import Path
+
+import duckdb
 
 from src.application.contracts import IBenchmarkService
 
@@ -9,12 +11,12 @@ class BenchmarkService(IBenchmarkService):
     def __init__(self, duckdb_context: duckdb.DuckDBPyConnection) -> None:
         self.__duckdb_context = duckdb_context
 
-    def download_parquet_as_shapefile_locally(self, azure_virtual_file_path: str, save_path: Path) -> None:
+    def download_parquet_as_shapefile_locally(self, virtual_file_path: str, save_path: Path) -> None:
         save_path.parent.mkdir(parents=True, exist_ok=True)
 
         self.__duckdb_context.execute(
             f"""
-            CREATE TABLE buildings AS SELECT * FROM read_parquet('{azure_virtual_file_path}');
+            CREATE TABLE buildings AS SELECT * FROM read_parquet('{virtual_file_path}');
             
             COPY (
                 SELECT * FROM buildings

--- a/src/infra/infrastructure/services/benchmark_service.py
+++ b/src/infra/infrastructure/services/benchmark_service.py
@@ -21,22 +21,14 @@ class BenchmarkService(IBenchmarkService):
 
         self.__duckdb_context.execute(
             f"""
-            CREATE  TABLE buildings AS SELECT
-                *,
-                bbox.maxx AS bbox_maxx,
-                bbox.maxy AS bbox_maxy,
-                bbox.minx AS bbox_minx,
-                bbox.miny AS bbox_miny,
-                bbox.xmax AS bbox_xmax,
-                bbox.xmin AS bbox_xmin,
-                bbox.ymax AS bbox_ymax,
-                bbox.ymin AS bbox_ymin
-            FROM read_parquet('{virtual_file_path}');
-
             COPY (
                 SELECT
-                    * EXCLUDE (bbox)
-                FROM buildings
+                    * EXCLUDE (bbox),
+                    bbox.maxx AS bbox_maxx,
+                    bbox.maxy AS bbox_maxy,
+                    bbox.minx AS bbox_minx,
+                    bbox.miny AS bbox_miny
+                FROM read_parquet('{virtual_file_path}')
             ) TO '{save_path.as_posix()}'
             WITH (
                 FORMAT GDAL,

--- a/src/infra/infrastructure/services/benchmark_service.py
+++ b/src/infra/infrastructure/services/benchmark_service.py
@@ -1,0 +1,27 @@
+﻿import duckdb
+
+from src.application.contracts import IBenchmarkService
+
+
+class BenchmarkService(IBenchmarkService):
+    __duckdb_context: duckdb.DuckDBPyConnection
+
+    def __init__(self, duckdb_context: duckdb.DuckDBPyConnection) -> None:
+        self.__duckdb_context = duckdb_context
+
+    def download_parquet_as_shapefile_locally(self, azure_virtual_file_path: str, save_path: Path) -> None:
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self.__duckdb_context.execute(
+            f"""
+            CREATE TABLE buildings AS SELECT * FROM read_parquet('{azure_virtual_file_path}');
+            
+            COPY (
+                SELECT * FROM buildings
+            ) TO '{str(save_path)}'
+            WITH (
+                FORMAT GDAL,
+                DRIVER 'ESRI Shapefile'
+            )
+            """
+        )

--- a/src/presentation/configuration/app_config.py
+++ b/src/presentation/configuration/app_config.py
@@ -17,6 +17,7 @@ def initialize_dependencies(run_id: str, benchmark_run: int) -> None:
             "src.presentation.entrypoints.bbox_filtering_advanced_postgis",
 
             "src.presentation.entrypoints.bbox_filtering_simple_local",
+            "src.presentation.entrypoints.bbox_filtering_simple_blob_storage",
 
             "src.presentation.entrypoints.setup_benchmarking_framework",
         ]

--- a/src/presentation/configuration/app_config.py
+++ b/src/presentation/configuration/app_config.py
@@ -12,8 +12,12 @@ def initialize_dependencies(run_id: str, benchmark_run: int) -> None:
             "src.application.common.monitor_utils",
             "src.presentation.entrypoints.db_scan_blob_storage",
             "src.presentation.entrypoints.db_scan_postgis",
+
             "src.presentation.entrypoints.bbox_filtering_advanced_duckdb",
             "src.presentation.entrypoints.bbox_filtering_advanced_postgis",
+
+            "src.presentation.entrypoints.bbox_filtering_simple_local",
+
             "src.presentation.entrypoints.setup_benchmarking_framework",
         ]
     )

--- a/src/presentation/entrypoints/__init__.py
+++ b/src/presentation/entrypoints/__init__.py
@@ -3,4 +3,6 @@ from .db_scan_blob_storage import db_scan_blob_storage
 from .db_scan_postgis import db_scan_postgis
 from .bbox_filtering_advanced_duckdb import bbox_filtering_advanced_duckdb
 from .bbox_filtering_advanced_postgis import bbox_filtering_advanced_postgis
+from .bbox_filtering_simple_local import bbox_filtering_simple_local
+from .bbox_filtering_simple_blob_storage import bbox_filtering_simple_blob_storage
 from .setup_benchmarking_framework import setup_benchmarking_framework

--- a/src/presentation/entrypoints/bbox_filtering_simple_blob_storage.py
+++ b/src/presentation/entrypoints/bbox_filtering_simple_blob_storage.py
@@ -1,0 +1,39 @@
+﻿import duckdb
+from dependency_injector.wiring import inject, Provide
+
+from src import Config
+from src.application.common.monitor import monitor
+from src.application.contracts import IFilePathService
+from src.domain.enums import StorageContainer, Theme
+from src.infra.infrastructure import Containers
+
+
+@inject
+@monitor(query_id="bbox-filtering-simple-blob-storage")
+def bbox_filtering_simple_blob_storage(
+        db_context: duckdb.DuckDBPyConnection = Provide[Containers.duckdb_context],
+        file_path_service: IFilePathService = Provide[Containers.file_path_service]
+) -> None:
+    min_lon = 10.40
+    max_lon = 10.95
+    min_lat = 59.70
+    max_lat = 60.10
+
+    path = file_path_service.create_release_virtual_filesystem_path(
+        storage_scheme="az",
+        container=StorageContainer.DATA,
+        release=Config.BENCHMARK_DOPPA_DATA_RELEASE,
+        theme=Theme.BUILDINGS,
+        region="*",
+        file_name="*.parquet"
+    )
+
+    db_context.execute(
+        f"""
+            SELECT * FROM read_parquet('{path}')
+            WHERE ST_Intersects(
+                geometry,
+                ST_MakeEnvelope({min_lon}, {min_lat}, {max_lon}, {max_lat})
+            );
+            """
+    )

--- a/src/presentation/entrypoints/bbox_filtering_simple_local.py
+++ b/src/presentation/entrypoints/bbox_filtering_simple_local.py
@@ -25,7 +25,7 @@ def _benchmark(db_context: duckdb.DuckDBPyConnection = Provide[Containers.duckdb
         f"""
         SELECT * FROM ST_ReadShp('{str(Config.BUILDINGS_SHAPEFILE)}')
         WHERE ST_Intersects(
-            geometry,
+            geom,
             ST_MakeEnvelope({min_lon}, {min_lat}, {max_lon}, {max_lat})
         );
         """

--- a/src/presentation/entrypoints/bbox_filtering_simple_local.py
+++ b/src/presentation/entrypoints/bbox_filtering_simple_local.py
@@ -1,0 +1,52 @@
+﻿import duckdb
+from dependency_injector.wiring import Provide, inject
+
+from src import Config
+from src.application.common.monitor import monitor
+from src.application.contracts import IFilePathService, IBenchmarkService
+from src.domain.enums import StorageContainer, Theme
+from src.infra.infrastructure import Containers
+
+
+def bbox_filtering_simple_local() -> None:
+    _download_data()
+    _benchmark()
+
+
+@inject
+@monitor(query_id="bbox-filtering-simple-local")
+def _benchmark(db_context: duckdb.DuckDBPyConnection = Provide[Containers.duckdb_context]) -> None:
+    min_lon = 10.40
+    max_lon = 10.95
+    min_lat = 59.70
+    max_lat = 60.10
+
+    db_context.execute(
+        f"""
+        SELECT * FROM ST_ReadShp('{str(Config.BUILDINGS_SHAPEFILE)}')
+        WHERE ST_Intersects(
+            geometry,
+            ST_MakeEnvelope({min_lon}, {min_lat}, {max_lon}, {max_lat})
+        );
+        """
+    )
+
+
+@inject
+def _download_data(
+        file_path_service: IFilePathService = Provide[Containers.file_path_service],
+        benchmark_service: IBenchmarkService = Provide[Containers.benchmark_service]
+) -> None:
+    virtual_file_path = file_path_service.create_release_virtual_filesystem_path(
+        storage_scheme="az",
+        container=StorageContainer.DATA,
+        release=Config.BENCHMARK_DOPPA_DATA_RELEASE,
+        theme=Theme.BUILDINGS,
+        region="*",
+        file_name="*.parquet"
+    )
+
+    benchmark_service.download_parquet_as_shapefile_locally(
+        virtual_file_path=virtual_file_path,
+        save_path=Config.BUILDINGS_SHAPEFILE
+    )


### PR DESCRIPTION
This pull request introduces two new benchmark types for bounding box filtering: one that operates on local shapefiles and another that works directly with GeoParquet files in blob storage. To support these, the codebase adds new services, dependency injection wiring, workflow steps, and configuration updates. These changes provide a more flexible benchmarking framework, allowing comparison between local and remote data access patterns.

**New Benchmark Types and Entrypoints**
- Added `bbox_filtering_simple_local` and `bbox_filtering_simple_blob_storage` benchmark entrypoints, each with corresponding Python modules implementing the logic for local shapefile and blob storage GeoParquet filtering. [[1]](diffhunk://#diff-3d56604d5d9f084b5272a98f4b414f53b0699ed34db4e05d010d86531048ed79R1-R52) [[2]](diffhunk://#diff-d48031cbd00ebca7b7537d281957e6d1436e8a0fd1e39e602a41741ebe1cdd95R1-R39)

**Infrastructure and Service Layer**
- Introduced a new `IBenchmarkService` interface and its implementation `BenchmarkService`, which provides a method to convert GeoParquet files from blob storage into local shapefiles for benchmarking. Dependency injection wiring for this service was added in the containers module. [[1]](diffhunk://#diff-7e1527210fb2a61bb80100c4bc7c2b38b60bd29a7ef9b978f0578139bd8ea913R1-R15) [[2]](diffhunk://#diff-72952e1b98d7996a8699043185aa8b1a856cf73aea92810d590937fec073584bR1-R46) [[3]](diffhunk://#diff-fe7ea827d54cbded7ab815c9d98375a634ce16aed370223bb77b1c84492a3c6bR9) [[4]](diffhunk://#diff-fe7ea827d54cbded7ab815c9d98375a634ce16aed370223bb77b1c84492a3c6bR105-R109)

**Configuration and Resource Management**
- Updated the configuration to include a new `BUILDINGS_SHAPEFILE` path for storing locally converted shapefiles.

**Workflow and Orchestration**
- Extended workflow YAML files (`.github/workflows/pull-request-tests.yml`, `.github/workflows/push-containers-to-acr.yml`, `benchmarks.yml`, `docker-compose.yml`) to include the new benchmark services, ensuring they are built, tested, and deployed as part of CI/CD and benchmarking runs. [[1]](diffhunk://#diff-972ccf921ef50999f7079000c7da03cb645fa38e4eec71ea20fb9915d187b13fR61-R66) [[2]](diffhunk://#diff-467550af1a819846a650bd0db72e2caaa65c08abbae064fe85baa5e13867292eR41-R48) [[3]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R21-R30) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R46-R63)

**Entrypoint Registration**
- Registered the new entrypoints in dependency injection configuration and module initializations, ensuring they are available for execution. [[1]](diffhunk://#diff-4777c42c10d232d09671b2a60e6a2d16f43139413cbae808ef3a4d833df650caR15-R21) [[2]](diffhunk://#diff-6293be55b065b6daf5745e1fc2f35b20f6c419f2ba5ec92e523c78916ec2b2f0R6-R7) [[3]](diffhunk://#diff-56f497f357c1a86b3152b78bc93c915029e06e2021f9a1b2ca20caf80a1823d8L7-R7) [[4]](diffhunk://#diff-56f497f357c1a86b3152b78bc93c915029e06e2021f9a1b2ca20caf80a1823d8R28-R33)

These changes collectively enable benchmarking of bounding box queries on both local and remote datasets, improving the flexibility and extensibility of the benchmarking framework.