### PR TITLE
Feature/127 pmtiles benchmark

### DIFF
--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -64,6 +64,9 @@ jobs:
           - service: bbox-filtering-simple-blob-storage
             display_name: Simple GeoParquet Bounding Box Filtering
 
+          - service: vector-tiles-single-tile-pmtiles
+            display_name: PMTiles Fetch Single Tile
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/push-containers-to-acr.yml
+++ b/.github/workflows/push-containers-to-acr.yml
@@ -46,6 +46,10 @@ jobs:
             image: bbox-filtering-simple-blob-storage
             display_name: Simple GeoParquet Bounding Box Filtering
 
+          - service: vector-tiles-single-tile-pmtiles
+            image: vector-tiles-single-tile-pmtiles
+            display_name: PMTiles Fetch Single Tile
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/benchmark_runner.py
+++ b/benchmark_runner.py
@@ -4,7 +4,8 @@ from typing import Optional
 from src.presentation.configuration import initialize_dependencies
 from src.presentation.entrypoints import (
     db_scan_blob_storage, db_scan_postgis, setup_benchmarking_framework, bbox_filtering_advanced_postgis,
-    bbox_filtering_advanced_duckdb, bbox_filtering_simple_local, bbox_filtering_simple_blob_storage
+    bbox_filtering_advanced_duckdb, bbox_filtering_simple_local, bbox_filtering_simple_blob_storage,
+    vector_tiles_single_tile_pmtiles
 )
 
 
@@ -30,6 +31,9 @@ def benchmark_runner() -> None:
             return
         case "bbox-filtering-simple-blob-storage":
             bbox_filtering_simple_blob_storage()
+            return
+        case "vector-tiles-single-tile-pmtiles":
+            vector_tiles_single_tile_pmtiles()
             return
         case "setup-framework":
             setup_benchmarking_framework()

--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -28,3 +28,8 @@ experiments:
     image: doppaacr.azurecr.io/bbox-filtering-simple-blob-storage:latest
     cpu: 4
     memory_gb: 16
+
+  - id: vector-tiles-single-tile-pmtiles
+    image: doppaacr.azurecr.io/vector-tiles-single-tile-pmtiles:latest
+    cpu: 4
+    memory_gb: 16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,3 +71,12 @@ services:
       dockerfile: .docker/Query.Dockerfile
     image: bbox-filtering-simple-blob-storage:latest
     command: python benchmark_runner.py --script-id bbox-filtering-simple-blob-storage
+
+  vector-tiles-single-tile-pmtiles:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: vector-tiles-single-tile-pmtiles:latest
+    command: python benchmark_runner.py --script-id vector-tiles-single-tile-pmtiles

--- a/requirements.txt
+++ b/requirements.txt
@@ -102,6 +102,7 @@ pandocfilters==1.5.1
 parso==0.8.5
 pillow==11.3.0
 platformdirs==4.4.0
+pmtiles==3.7.0
 prometheus_client==0.23.1
 prompt_toolkit==3.0.52
 propcache==0.4.1

--- a/src/application/contracts/file_path_service_interface.py
+++ b/src/application/contracts/file_path_service_interface.py
@@ -7,6 +7,17 @@ from src.domain.enums import Theme, StorageContainer
 class IFilePathService(ABC):
     @staticmethod
     @abstractmethod
+    def create_url_to_blob_resource(container: StorageContainer, blob_path: str) -> str:
+        """
+        Creates a URL to a blob resource in a storage account.
+        :param container: Container where the blob is stored
+        :param blob_path: Path to blob resource within the container
+        :return: A URL to the blob resource
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
     def create_hive_blob_path(
             file_name: str,
             **kwargs: str | int

--- a/src/config.py
+++ b/src/config.py
@@ -17,6 +17,7 @@ class Config:
     # AZURE
     AZURE_RESOURCE_GROUP: str = "doppa"
     AZURE_RESOURCE_LOCATION: str = "norwayeast"
+    AZURE_BLOB_STORAGE_HTTPS_URL: str = "https://doppablobstorage.blob.core.windows.net"
     AZURE_BLOB_STORAGE_ACCOUNT_NAME: str = "doppablobstorage"
     AZURE_BLOB_STORAGE_CONNECTION_STRING: str = os.getenv("AZURE_BLOB_STORAGE_CONNECTION_STRING")
     BLOB_STORAGE_MAX_CONCURRENCY: int = 1

--- a/src/infra/infrastructure/services/file_path_service.py
+++ b/src/infra/infrastructure/services/file_path_service.py
@@ -2,11 +2,16 @@
 from datetime import datetime
 from typing import Literal
 
+from src import Config
 from src.application.contracts import IFilePathService
 from src.domain.enums import Theme, StorageContainer
 
 
 class FilePathService(IFilePathService):
+    @staticmethod
+    def create_url_to_blob_resource(container: StorageContainer, blob_path: str) -> str:
+        return f"{Config.AZURE_BLOB_STORAGE_HTTPS_URL}/{container.value}/{blob_path}"
+
     @staticmethod
     def create_hive_blob_path(
             file_name: str,

--- a/src/presentation/configuration/app_config.py
+++ b/src/presentation/configuration/app_config.py
@@ -19,6 +19,8 @@ def initialize_dependencies(run_id: str, benchmark_run: int) -> None:
             "src.presentation.entrypoints.bbox_filtering_simple_local",
             "src.presentation.entrypoints.bbox_filtering_simple_blob_storage",
 
+            "src.presentation.entrypoints.vector_tiles_single_tile_pmtiles",
+
             "src.presentation.entrypoints.setup_benchmarking_framework",
         ]
     )

--- a/src/presentation/entrypoints/__init__.py
+++ b/src/presentation/entrypoints/__init__.py
@@ -6,3 +6,4 @@ from .bbox_filtering_advanced_postgis import bbox_filtering_advanced_postgis
 from .bbox_filtering_simple_local import bbox_filtering_simple_local
 from .bbox_filtering_simple_blob_storage import bbox_filtering_simple_blob_storage
 from .setup_benchmarking_framework import setup_benchmarking_framework
+from .vector_tiles_single_tile_pmtiles import vector_tiles_single_tile_pmtiles

--- a/src/presentation/entrypoints/vector_tiles_single_tile_pmtiles.py
+++ b/src/presentation/entrypoints/vector_tiles_single_tile_pmtiles.py
@@ -1,0 +1,30 @@
+﻿import requests
+from dependency_injector.wiring import inject, Provide
+from pmtiles.reader import Reader
+
+from src import Config
+from src.application.common.monitor_network import monitor_network
+from src.application.contracts import IFilePathService
+from src.domain.enums import StorageContainer
+from src.infra.infrastructure import Containers
+
+Z, X, Y = 15, 17361, 9529
+
+
+@inject
+def vector_tiles_pmtiles(file_path_service: IFilePathService = Provide[Containers.file_path_service]) -> None:
+    pmtiles_azure_path = file_path_service.create_url_to_blob_resource(
+        container=StorageContainer.TILES,
+        blob_path=Config.BUILDINGS_PMTILES_FILE.name
+    )
+
+    response = requests.get(pmtiles_azure_path, stream=True)
+    response.raise_for_status()
+
+    reader = Reader(response.raw)
+    _benchmark(reader=reader)
+
+
+@monitor_network(query_id="vector-tiles-pmtiles")
+def _benchmark(reader: Reader) -> None:
+    reader.get(Z, X, Y)

--- a/src/presentation/entrypoints/vector_tiles_single_tile_pmtiles.py
+++ b/src/presentation/entrypoints/vector_tiles_single_tile_pmtiles.py
@@ -43,8 +43,34 @@ def _http_range_source(url: str) -> Callable:
             "Accept-Encoding": "identity",
         }
         r = session.get(url, headers=headers, stream=False, timeout=30)
-        if r.status_code not in (200, 206):
-            r.raise_for_status()
+        if r.status_code != 206:
+            if r.status_code != 200:
+                r.raise_for_status()
+            raise RuntimeError(f"Expected HTTP 206 Partial Content for range request, got {r.status_code}")
+
+        content_range = r.headers.get("Content-Range")
+        if content_range:
+            try:
+                units, range_spec = content_range.split(" ", 1)
+                if units.strip().lower() != "bytes":
+                    raise ValueError("Unsupported Content-Range units")
+                byte_range, _ = range_spec.split("/", 1)
+                start_str, end_str = byte_range.split("-", 1)
+                start = int(start_str)
+                end_returned = int(end_str)
+            except Exception as exc:
+                raise RuntimeError(f"Invalid Content-Range header: {content_range}") from exc
+            if start != offset or (end_returned - start + 1) != length:
+                raise RuntimeError(
+                    f"Server returned unexpected byte range {content_range} "
+                    f"for requested offset={offset}, length={length}"
+                )
+
+        if len(r.content) != length:
+            raise RuntimeError(
+                f"Server returned {len(r.content)} bytes, expected {length} "
+                f"for offset={offset}"
+            )
         return r.content
 
     return _get_bytes

--- a/src/presentation/entrypoints/vector_tiles_single_tile_pmtiles.py
+++ b/src/presentation/entrypoints/vector_tiles_single_tile_pmtiles.py
@@ -1,4 +1,6 @@
-﻿import requests
+﻿from typing import Callable
+
+import requests
 from dependency_injector.wiring import inject, Provide
 from pmtiles.reader import Reader
 
@@ -8,23 +10,41 @@ from src.application.contracts import IFilePathService
 from src.domain.enums import StorageContainer
 from src.infra.infrastructure import Containers
 
-Z, X, Y = 15, 17361, 9529
+Z, X, Y = 13, 4340, 2382
 
 
 @inject
-def vector_tiles_pmtiles(file_path_service: IFilePathService = Provide[Containers.file_path_service]) -> None:
-    pmtiles_azure_path = file_path_service.create_url_to_blob_resource(
+def vector_tiles_single_tile_pmtiles(
+        file_path_service: IFilePathService = Provide[Containers.file_path_service]
+) -> None:
+    pmtiles_azure_url = file_path_service.create_url_to_blob_resource(
         container=StorageContainer.TILES,
         blob_path=Config.BUILDINGS_PMTILES_FILE.name
     )
 
-    response = requests.get(pmtiles_azure_path, stream=True)
-    response.raise_for_status()
-
-    reader = Reader(response.raw)
+    reader = Reader(_http_range_source(url=pmtiles_azure_url))
     _benchmark(reader=reader)
 
 
-@monitor_network(query_id="vector-tiles-pmtiles")
+@monitor_network(query_id="vector-tiles-single-tile-pmtiles")
 def _benchmark(reader: Reader) -> None:
-    reader.get(Z, X, Y)
+    tile_bytes = reader.get(Z, X, Y)
+    if tile_bytes is None:
+        raise RuntimeError("Tile not found in archive")
+
+
+def _http_range_source(url: str) -> Callable:
+    session = requests.Session()
+
+    def _get_bytes(offset: int, length: int) -> bytes:
+        end = offset + length - 1
+        headers = {
+            "Range": f"bytes={offset}-{end}",
+            "Accept-Encoding": "identity",
+        }
+        r = session.get(url, headers=headers, stream=False, timeout=30)
+        if r.status_code not in (200, 206):
+            r.raise_for_status()
+        return r.content
+
+    return _get_bytes


### PR DESCRIPTION
This pull request introduces a new benchmark experiment and service for fetching a single vector tile from a PMTiles archive stored in Azure Blob Storage. The changes add support for this new benchmark across configuration, orchestration, and implementation layers.

**Benchmark and Service Addition**

* Added a new experiment configuration for `vector-tiles-single-tile-pmtiles` in `benchmarks.yml`, specifying its container image and resource requirements.
* Updated `docker-compose.yml` and GitHub workflow files to include the new `vector-tiles-single-tile-pmtiles` service for local and CI runs. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R74-R82) [[2]](diffhunk://#diff-972ccf921ef50999f7079000c7da03cb645fa38e4eec71ea20fb9915d187b13fR67-R69) [[3]](diffhunk://#diff-467550af1a819846a650bd0db72e2caaa65c08abbae064fe85baa5e13867292eR49-R52)

**Implementation and Dependency Wiring**

* Implemented the benchmark logic in `src/presentation/entrypoints/vector_tiles_single_tile_pmtiles.py`, which fetches a single tile from a PMTiles archive using HTTP range requests and the `pmtiles` library.
* Registered the new entrypoint in the dependency injection configuration and initialization code, ensuring it is available for benchmarking runs. [[1]](diffhunk://#diff-4777c42c10d232d09671b2a60e6a2d16f43139413cbae808ef3a4d833df650caR22-R23) [[2]](diffhunk://#diff-6293be55b065b6daf5745e1fc2f35b20f6c419f2ba5ec92e523c78916ec2b2f0R9) [[3]](diffhunk://#diff-56f497f357c1a86b3152b78bc93c915029e06e2021f9a1b2ca20caf80a1823d8L7-R8) [[4]](diffhunk://#diff-56f497f357c1a86b3152b78bc93c915029e06e2021f9a1b2ca20caf80a1823d8R35-R37)

**Infrastructure and Utilities**

* Added a static method `create_url_to_blob_resource` to the `IFilePathService` interface and implemented it in `FilePathService`, allowing construction of blob URLs for resources in Azure storage. Also added the HTTPS URL to the config. [[1]](diffhunk://#diff-f83c7374fb73bcf97a66cc85f2e82ac40f0c7b65e22c3be3e0c6dc72c8c49e33R8-R18) [[2]](diffhunk://#diff-3eadca0abc50155e32036729b6c7b8179beb63be5e04e057c21df62d8d34338bR5-R14) [[3]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592R20)