### PR TITLE
#122 Renamed CPU and RAM monitoring method

### DIFF
--- a/src/application/common/monitor_cpu_and_ram.py
+++ b/src/application/common/monitor_cpu_and_ram.py
@@ -10,7 +10,7 @@ from src.application.common import logger
 from src.application.common.monitor_utils import _get_run_id, _get_benchmark_run, _save_run_metadata, _save_run
 
 
-def monitor(query_id: str, interval: float = Config.DEFAULT_SAMPLE_TIMEOUT):
+def monitor_cpu_and_ram(query_id: str, interval: float = Config.DEFAULT_SAMPLE_TIMEOUT):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):

--- a/src/presentation/entrypoints/bbox_filtering_simple_blob_storage.py
+++ b/src/presentation/entrypoints/bbox_filtering_simple_blob_storage.py
@@ -2,14 +2,14 @@
 from dependency_injector.wiring import inject, Provide
 
 from src import Config
-from src.application.common.monitor import monitor
+from src.application.common.monitor_cpu_and_ram import monitor_cpu_and_ram
 from src.application.contracts import IFilePathService
 from src.domain.enums import StorageContainer, Theme
 from src.infra.infrastructure import Containers
 
 
 @inject
-@monitor(query_id="bbox-filtering-simple-blob-storage")
+@monitor_cpu_and_ram(query_id="bbox-filtering-simple-blob-storage")
 def bbox_filtering_simple_blob_storage(
         db_context: duckdb.DuckDBPyConnection = Provide[Containers.duckdb_context],
         file_path_service: IFilePathService = Provide[Containers.file_path_service]

--- a/src/presentation/entrypoints/bbox_filtering_simple_local.py
+++ b/src/presentation/entrypoints/bbox_filtering_simple_local.py
@@ -2,7 +2,7 @@
 from dependency_injector.wiring import Provide, inject
 
 from src import Config
-from src.application.common.monitor import monitor
+from src.application.common.monitor_cpu_and_ram import monitor_cpu_and_ram
 from src.application.contracts import IFilePathService, IBenchmarkService
 from src.domain.enums import StorageContainer, Theme
 from src.infra.infrastructure import Containers
@@ -14,7 +14,7 @@ def bbox_filtering_simple_local() -> None:
 
 
 @inject
-@monitor(query_id="bbox-filtering-simple-local")
+@monitor_cpu_and_ram(query_id="bbox-filtering-simple-local")
 def _benchmark(db_context: duckdb.DuckDBPyConnection = Provide[Containers.duckdb_context]) -> None:
     min_lon = 10.40
     max_lon = 10.95

--- a/src/presentation/entrypoints/db_scan_blob_storage.py
+++ b/src/presentation/entrypoints/db_scan_blob_storage.py
@@ -2,14 +2,14 @@
 from duckdb import DuckDBPyConnection
 
 from src import Config
-from src.application.common.monitor import monitor
+from src.application.common.monitor_cpu_and_ram import monitor_cpu_and_ram
 from src.application.contracts import IFilePathService
 from src.domain.enums import StorageContainer, Theme
 from src.infra.infrastructure import Containers
 
 
 @inject
-@monitor(query_id="db-scan-blob-storage")
+@monitor_cpu_and_ram(query_id="db-scan-blob-storage")
 def db_scan_blob_storage(
         db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
         path_service: IFilePathService = Provide[Containers.file_path_service]

--- a/src/presentation/entrypoints/db_scan_postgis.py
+++ b/src/presentation/entrypoints/db_scan_postgis.py
@@ -1,12 +1,12 @@
 ﻿from dependency_injector.wiring import inject, Provide
 from sqlalchemy import Engine, text
 
-from src.application.common.monitor import monitor
+from src.application.common.monitor_cpu_and_ram import monitor_cpu_and_ram
 from src.infra.infrastructure import Containers
 
 
 @inject
-@monitor(query_id="db-scan-postgis")
+@monitor_cpu_and_ram(query_id="db-scan-postgis")
 def db_scan_postgis(
         db_context: Engine = Provide[Containers.postgres_context]
 ) -> None:


### PR DESCRIPTION
This pull request refactors the monitoring functionality across several entrypoints by renaming and updating the monitoring decorator to better reflect its purpose. The main focus is on improving code clarity by making it explicit that the monitoring is for CPU and RAM usage.

**Monitoring decorator refactor:**

* Renamed the monitoring decorator from `monitor` to `monitor_cpu_and_ram` in `src/application/common/monitor_cpu_and_ram.py` (previously `monitor.py`) to clarify its purpose.
* Updated all entrypoints (`bbox_filtering_simple_blob_storage.py`, `bbox_filtering_simple_local.py`, `db_scan_blob_storage.py`, `db_scan_postgis.py`) to use the new `monitor_cpu_and_ram` decorator instead of the old `monitor` decorator. [[1]](diffhunk://#diff-d48031cbd00ebca7b7537d281957e6d1436e8a0fd1e39e602a41741ebe1cdd95L5-R12) [[2]](diffhunk://#diff-3d56604d5d9f084b5272a98f4b414f53b0699ed34db4e05d010d86531048ed79L5-R5) [[3]](diffhunk://#diff-196159f3fc78bfbfa5b1dc74231a91c2acc8dd9cce7a7615d5ab730663454dacL5-R12) [[4]](diffhunk://#diff-77d680b08c333dae7ac98518eb99f096d8bc85e429c0c05908a2b98b319747ebL4-R9)

**Entrypoint function updates:**

* Replaced the usage of `@monitor` with `@monitor_cpu_and_ram` in all relevant functions to ensure consistent monitoring of CPU and RAM usage. [[1]](diffhunk://#diff-d48031cbd00ebca7b7537d281957e6d1436e8a0fd1e39e602a41741ebe1cdd95L5-R12) [[2]](diffhunk://#diff-3d56604d5d9f084b5272a98f4b414f53b0699ed34db4e05d010d86531048ed79L17-R17) [[3]](diffhunk://#diff-196159f3fc78bfbfa5b1dc74231a91c2acc8dd9cce7a7615d5ab730663454dacL5-R12) [[4]](diffhunk://#diff-77d680b08c333dae7ac98518eb99f096d8bc85e429c0c05908a2b98b319747ebL4-R9)

These changes improve code readability and make the monitoring intent explicit throughout the codebase.