### PR TITLE
#139 Changed azcliversion to latest

### DIFF
--- a/.github/workflows/publish-api.yml
+++ b/.github/workflows/publish-api.yml
@@ -90,7 +90,7 @@ jobs:
           BLOB_BENCHMARK: ${{ vars.AZURE_BLOB_STORAGE_BENCHMARK_CONTAINER }}
           BLOB_METADATA: ${{ vars.AZURE_BLOB_STORAGE_METADATA_CONTAINER }}
         with:
-          azcliversion: 2.63.0
+          azcliversion: latest
           inlineScript: |
             az webapp config appsettings set \
               --name "$WEBAPP_NAME" \


### PR DESCRIPTION
This pull request updates the Azure CLI version used in the `publish-api.yml` GitHub Actions workflow to ensure the most recent features and fixes are available.

Workflow configuration update:

* Changed the `azcliversion` parameter in `.github/workflows/publish-api.yml` from `2.63.0` to `latest`, allowing the workflow to always use the newest Azure CLI version.