### PR TITLE
Bugfix/143 benchmark script exiting early

### DIFF
--- a/.docker/Orchestrator.Dockerfile
+++ b/.docker/Orchestrator.Dockerfile
@@ -2,21 +2,10 @@
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    ca-certificates \
-    gnupg \
-    libexpat1 \
-    gdal-bin \
-    libgdal-dev \
-    build-essential \
-    && curl -sL https://aka.ms/InstallAzureCLIDeb | bash \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV GDAL_CONFIG=/usr/bin/gdal-config
-
-COPY requirements.txt .
-RUN python -m pip install --upgrade pip setuptools wheel
-RUN python -m pip install --no-cache-dir -r requirements.txt
+RUN apt-get update && \
+    apt-get install -y curl ca-certificates gnupg && \
+    curl -sL https://aka.ms/InstallAzureCLIDeb | bash && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY . .
+RUN pip install -r requirements.txt

--- a/.docker/Orchestrator.Dockerfile
+++ b/.docker/Orchestrator.Dockerfile
@@ -9,3 +9,5 @@ RUN apt-get update && \
 
 COPY . .
 RUN pip install -r requirements.txt
+
+ENTRYPOINT ["python", "-m", "main"]

--- a/src/presentation/entrypoints/vector_tiles_100k_vmt.py
+++ b/src/presentation/entrypoints/vector_tiles_100k_vmt.py
@@ -1,0 +1,57 @@
+﻿import random
+from itertools import islice, cycle
+from typing import Iterable
+
+from dependency_injector.wiring import inject, Provide
+
+from src import Config
+from src.application.common import logger
+from src.application.common.monitor_network import monitor_network
+from src.application.contracts import ITileApiService, ITileService
+from src.infra.infrastructure import Containers
+
+TOTAL_REQUEST: int = 100_000
+ZOOM_LEVEL: int = 13
+
+
+@inject
+def vector_tiles_100k_vmt(
+        tile_service: ITileService = Provide[Containers.tile_service],
+        tile_api_service: ITileApiService = Provide[Containers.tile_api_service],
+) -> None:
+    logger.info("Setting up benchmark")
+    min_lat, min_lon, max_lat, max_lon = Config.BUILDINGS_SPATIAL_EXTENT
+    existing_tiles: list[tuple[int, int, int]] = []
+    tiles = tile_service.build_candidate_tiles(
+        min_lat=min_lat,
+        min_lon=min_lon,
+        max_lat=max_lat,
+        max_lon=max_lon,
+        zoom=ZOOM_LEVEL
+    )
+
+    for test_tile in tiles:
+        z, x, y = test_tile
+        response = tile_api_service.fetch_vmt_tile(z=z, x=x, y=y)
+        if response is not None:
+            existing_tiles.append(test_tile)
+
+    if not existing_tiles:
+        raise RuntimeError("No candidate tiles found")
+
+    print(existing_tiles)
+    logger.info(f"Found {len(existing_tiles)} tiles. Repeating until {TOTAL_REQUEST} tiles are generated.")
+    random.shuffle(tiles)
+    tiles_to_request = islice(cycle(existing_tiles), TOTAL_REQUEST)
+
+    _benchmark(tiles=tiles_to_request)
+
+
+@inject
+@monitor_network(query_id="vector-tiles-100k-vmt")
+def _benchmark(
+        tiles: Iterable[tuple[int, int, int]],
+        tile_api_service: ITileApiService = Provide[Containers.tile_api_service],
+) -> None:
+    for z, x, y in tiles:
+        tile_api_service.fetch_vmt_tile(z=z, x=x, y=y)


### PR DESCRIPTION
This pull request introduces a new benchmarking entrypoint for vector tile requests and streamlines the Dockerfile for the orchestrator service. The main focus is on enabling large-scale benchmarking of vector tile API performance and simplifying the build process.

Benchmarking functionality:

* Added `vector_tiles_100k_vmt.py` entrypoint that benchmarks vector tile API performance by issuing 100,000 requests at zoom level 13, using candidate tiles within a defined spatial extent. The benchmark repeats requests for valid tiles and monitors network activity for performance analysis.

Build process simplification:

* Simplified `.docker/Orchestrator.Dockerfile` by removing unnecessary packages (`gdal-bin`, `libgdal-dev`, `libexpat1`, `build-essential`), consolidating pip install commands, and adding an explicit `ENTRYPOINT` for running the orchestrator.