### PR TITLE
#146 Changed from self-hosted runner to GitHub runner on Ubuntu

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -16,11 +16,7 @@ permissions:
 jobs:
   run-benchmarks:
     name: Run Benchmarks via Orchestrator
-    runs-on:
-      - self-hosted
-      - Linux
-      - ARM64
-      - raspberrypi5
+    runs-on: ubuntu-latest
 
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 


### PR DESCRIPTION
This pull request makes a small change to the benchmark workflow configuration. The runner environment for the `run-benchmarks` job has been updated to use the `ubuntu-latest` GitHub-hosted runner instead of a self-hosted Raspberry Pi ARM64 runner.