### PR TITLE
#148 Injected vector_tiles_100k_pmtiles

### DIFF
--- a/src/presentation/configuration/app_config.py
+++ b/src/presentation/configuration/app_config.py
@@ -23,6 +23,7 @@ def initialize_dependencies(run_id: str, benchmark_run: int) -> None:
             "src.presentation.entrypoints.vector_tiles_single_tile_vmt",
 
             "src.presentation.entrypoints.vector_tiles_100k_vmt",
+            "src.presentation.entrypoints.vector_tiles_100k_pmtiles",
 
             "src.presentation.entrypoints.setup_benchmarking_framework",
 


### PR DESCRIPTION
This pull request makes a minor update to the dependency initialization in the application configuration. It adds a new entrypoint for vector tiles using the PMTiles format.

* Dependency configuration update:
  * Added `"src.presentation.entrypoints.vector_tiles_100k_pmtiles"` to the list of dependencies in the `initialize_dependencies` function in `app_config.py`.