### PR TITLE
Bugfix/165 default azure credentials failed to retrieve token

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run Orchestrator Container
         env:
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-          AZURE_UAMI_RESROUCE_ID: ${{ secrets.AZURE_UAMI_RESOURCE_ID }}
+          AZURE_UAMI_RESOURCE_ID: ${{ secrets.AZURE_UAMI_RESOURCE_ID }}
           ACR_LOGIN_SERVER: ${{ vars.ACR_LOGIN_SERVER }}
           ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
           ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
@@ -56,7 +56,7 @@ jobs:
           docker run --rm
           -v "$HOME/.azure:/root/.azure"
           -e AZURE_SUBSCRIPTION_ID
-          -e AZURE_UAMI_RESROUCE_ID
+          -e AZURE_UAMI_RESOURCE_ID
           -e ACR_LOGIN_SERVER
           -e ACR_USERNAME
           -e ACR_PASSWORD

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Run Orchestrator Container
         env:
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          AZURE_UAMI_RESROUCE_ID: ${{ secrets.AZURE_UAMI_RESOURCE_ID }}
           ACR_LOGIN_SERVER: ${{ vars.ACR_LOGIN_SERVER }}
           ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
           ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
@@ -55,6 +56,7 @@ jobs:
           docker run --rm
           -v "$HOME/.azure:/root/.azure"
           -e AZURE_SUBSCRIPTION_ID
+          -e AZURE_UAMI_RESROUCE_ID
           -e ACR_LOGIN_SERVER
           -e ACR_USERNAME
           -e ACR_PASSWORD

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ The next step is to give the UAMI a `Contributor` in the resource group. Navigat
 setting and press *Add role assignment*. Select the scope `Resource group` and then the resource group `doppa`. Pick the
 role `Contributor` and press *Save*.
 
+To view the `AZURE_UAMI_RESOURCE_ID` (needed for later) run the following command: 
+
+```powershell
+az identity show -g doppa -n doppa-github-ci --query id -o tsv
+```
+
 #### Container registry
 
 Create a container registry named `doppaacr`. The Docker images will be saved here. To ensure that the Actions are able
@@ -129,6 +135,7 @@ Navigate to *Review + create* and create the resource. Repeat this process for e
 
 In your repository navigate to *Secrets and variables* under *Settings*. Add the following **secrets**:
 
+- `AZURE_UAMI_RESOURCE_ID`
 - `ACR_NAME`
 - `ACR_PASSWORD`
 - `ACR_USERNAME`
@@ -175,6 +182,7 @@ results from actual runs.
 
 ```dotenv
 AZURE_SUBSCRIPTION_ID=<azure-subscription-id>
+AZURE_UAMI_RESOURCE_ID=<azure-user-assigned-managed-identity-resource-id>
 
 AZURE_BLOB_STORAGE_CONNECTION_STRING=<azure-blob-storage-connection-string>
 AZURE_BLOB_STORAGE_BENCHMARK_CONTAINER=dev-benchmarks

--- a/main.py
+++ b/main.py
@@ -156,6 +156,8 @@ def _create_container_instance(
 
         "--command-line", startup_command,
 
+        "--assign-identity", Config.AZURE_UAMI_RESOURCE_ID,
+
         "--registry-login-server", acr_login_server,
         "--registry-username", acr_username,
         "--registry-password", acr_password,

--- a/src/config.py
+++ b/src/config.py
@@ -18,6 +18,7 @@ class Config:
     AZURE_RESOURCE_GROUP: str = "doppa"
     AZURE_RESOURCE_LOCATION: str = "norwayeast"
     AZURE_SUBSCRIPTION_ID: str = os.getenv("AZURE_SUBSCRIPTION_ID")
+    AZURE_UAMI_RESOURCE_ID: str = os.getenv("AZURE_UAMI_RESOURCE_ID")
 
     AZURE_BLOB_STORAGE_HTTPS_URL: str = "https://doppablobstorage.blob.core.windows.net"
     AZURE_BLOB_STORAGE_ACCOUNT_NAME: str = "doppablobstorage"


### PR DESCRIPTION
This pull request introduces support for using a user-assigned managed identity (UAMI) when running orchestrator containers in Azure. The changes include updates to configuration, workflow files, documentation, and code to ensure the UAMI resource ID is correctly passed and used throughout the deployment process.

**Azure UAMI integration:**

* Added `AZURE_UAMI_RESOURCE_ID` as a required secret and environment variable in the GitHub Actions workflow (`.github/workflows/run-benchmarks.yml`) and ensured it is passed to the orchestrator container. [[1]](diffhunk://#diff-00107fb05307cc943b796fe04be904eaec8aaeacd416c00a9fc3d0ed281f25b7R44) [[2]](diffhunk://#diff-00107fb05307cc943b796fe04be904eaec8aaeacd416c00a9fc3d0ed281f25b7R59)
* Updated the `Config` class in `src/config.py` to load `AZURE_UAMI_RESOURCE_ID` from the environment.
* Modified `_create_container_instance` in `main.py` to assign the UAMI to the Azure container instance using the provided resource ID.

**Documentation updates:**

* Added instructions to the `README.md` for retrieving the UAMI resource ID and updated the list of required secrets and `.env` variables to include `AZURE_UAMI_RESOURCE_ID`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R70-R75) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R138) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R185)