### PR TITLE
#176 Changed single tile iterations from 600 to 1500

### DIFF
--- a/src/domain/enums/benchmark_iteration.py
+++ b/src/domain/enums/benchmark_iteration.py
@@ -5,7 +5,7 @@ from src import Config
 
 class BenchmarkIteration(Enum):
     DB_SCAN = 1_000
-    VECTOR_TILE_SINGLE_TILE = 600
+    VECTOR_TILE_SINGLE_TILE = 1500
     VECTOR_TILE_100K = 2
     BBOX_FILTERING_SIMPLE = 1000
     BBOX_FILTERING_ADVANCED = 100


### PR DESCRIPTION
This pull request makes a small change to the `BenchmarkIteration` enum. The value for `VECTOR_TILE_SINGLE_TILE` has been updated to reflect a new iteration count.

* Increased the value of `VECTOR_TILE_SINGLE_TILE` from 600 to 1500 in the `BenchmarkIteration` enum in `benchmark_iteration.py`.