### PR TITLE
#180 Added repository keyword to install

### DIFF
--- a/src/infra/persistence/context/duckdb.py
+++ b/src/infra/persistence/context/duckdb.py
@@ -11,7 +11,7 @@ def create_duckdb_context() -> duckdb.DuckDBPyConnection:
     db_context.load_extension("spatial")
     db_context.install_extension("azure")
     db_context.load_extension("azure")
-    db_context.install_extension("h3")
+    db_context.install_extension("h3", repository="community")
     db_context.load_extension("h3")
 
     db_context.execute("""


### PR DESCRIPTION
This pull request makes a minor update to the way the `h3` extension is installed in the DuckDB context. The installation now specifies the `community` repository, which may improve compatibility or reliability when installing the extension.

* [`src/infra/persistence/context/duckdb.py`](diffhunk://#diff-b824b4fde4d3b50d2ad1043b51c61be62eb8bc03c16380fbc597eac8e7ef5130L14-R14): Changed the `install_extension` call for `h3` to specify `repository="community"` in the `create_duckdb_context` function.