### PR TITLE
#184 Reduced benchmark runs to 1

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -104,7 +104,7 @@ class Config:
     BENCHMARK_FILE: Path = ROOT_DIR / "benchmarks.yml"
     RUN_ID_LENGTH: int = 6
     DEFAULT_SAMPLE_TIMEOUT: float = 0.01
-    BENCHMARK_RUNS: int = 5
+    BENCHMARK_RUNS: int = 1
     BENCHMARK_WARMUP_ITERATIONS: int = 5
     BENCHMARK_ITERATIONS: int = 100
     BENCHMARK_METADATA_BLOB_NAME: str = "benchmark_metadata.parquet"


### PR DESCRIPTION
This pull request makes a small configuration change to the benchmarking settings. The number of benchmark runs has been reduced from 5 to 1.

* Decreased the default value of `BENCHMARK_RUNS` in the `Config` class in `src/config.py` from 5 to 1, which will cause benchmarks to run only once by default.