### PR TITLE
#191 Added missing containers to PR test

### DIFF
--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -64,6 +64,33 @@ jobs:
           - service: bbox-filtering-simple-blob-storage
             display_name: Simple GeoParquet Bounding Box Filtering
 
+          - service: bbox-filtering-result-set-sizes-neighborhood-duckdb
+            display_name: Neighborhood DuckDB Bounding Box Filtering Result Set Sizes
+
+          - service: bbox-filtering-result-set-sizes-municipality-duckdb
+            display_name: Municipality DuckDB Bounding Box Filtering Result Set Sizes
+
+          - service: bbox-filtering-result-set-sizes-county-duckdb
+            display_name: County DuckDB Bounding Box Filtering Result Set Sizes
+
+          - service: bbox-filtering-result-set-sizes-neighborhood-postgis
+            display_name: Neighborhood PostGIS Bounding Box Filtering Result Set Sizes
+
+          - service: bbox-filtering-result-set-sizes-municipality-postgis
+            display_name: Municipality PostGIS Bounding Box Filtering Result Set Sizes
+
+          - service: bbox-filtering-result-set-sizes-county-postgis
+            display_name: County PostGIS Bounding Box Filtering Result Set Sizes
+
+          - service: bbox-filtering-result-set-sizes-neighborhood-local
+            display_name: Neighborhood Local Bounding Box Filtering Result Set Sizes
+
+          - service: bbox-filtering-result-set-sizes-municipality-local
+            display_name: Municipality Local Bounding Box Filtering Result Set Sizes
+
+          - service: bbox-filtering-result-set-sizes-county-local
+            display_name: County Local Bounding Box Filtering Result Set Sizes
+
           - service: vector-tiles-single-tile-pmtiles
             display_name: PMTiles Fetch Single Tile
 


### PR DESCRIPTION
This pull request adds several new services to the pull request test workflow, expanding coverage for bounding box filtering result set sizes across different geographic levels and storage backends. These additions will help ensure that the result set size calculations are tested for neighborhoods, municipalities, and counties using DuckDB, PostGIS, and local storage implementations.

**Enhancements to test coverage for bounding box filtering result set sizes:**

* Added services for result set size calculations at the neighborhood, municipality, and county levels using DuckDB (`bbox-filtering-result-set-sizes-neighborhood-duckdb`, `bbox-filtering-result-set-sizes-municipality-duckdb`, `bbox-filtering-result-set-sizes-county-duckdb`).
* Added services for result set size calculations at the neighborhood, municipality, and county levels using PostGIS (`bbox-filtering-result-set-sizes-neighborhood-postgis`, `bbox-filtering-result-set-sizes-municipality-postgis`, `bbox-filtering-result-set-sizes-county-postgis`).
* Added services for result set size calculations at the neighborhood, municipality, and county levels using local storage (`bbox-filtering-result-set-sizes-neighborhood-local`, `bbox-filtering-result-set-sizes-municipality-local`, `bbox-filtering-result-set-sizes-county-local`).