### PR TITLE
#200 Added POSTGRES_SERVER_NAME to enviornment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ AZURE_BLOB_STORAGE_METADATA_CONTAINER=dev-metadata
 
 ACR_LOGIN_SERVER=<azure-container-registry-login-server>
 
-POSTGRES_SERVER_NAME=doppa-db
+POSTGRES_SERVER_NAME=<postgres-server-name>
 POSTGRES_USERNAME=<postgres-username>
 POSTGRES_PASSWORD=<postgres-password>
 ```


### PR DESCRIPTION
This pull request makes a small update to the `README.md` file, replacing a hardcoded example value for the `POSTGRES_SERVER_NAME` environment variable with a placeholder to clarify that users should substitute their own server name.