### PR TITLE
#208 Updated workflow to create container on ACI and finish job

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -2,7 +2,7 @@ name: Run Benchmarks
 
 on:
   schedule:
-    - cron: "30 3 * * *"
+    - cron: "30 3 * * 1"
   workflow_dispatch:
 
 concurrency:
@@ -28,40 +28,39 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Log in to ACR
-        run: az acr login --name ${{ vars.ACR_NAME }}
-
-      - name: Pull Orchestrator from ACR
-        run: docker pull ${{ vars.ACR_LOGIN_SERVER }}/container-orchestrator:latest
-
-      - name: Run Orchestrator Container
-        env:
-          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-          AZURE_UAMI_RESOURCE_ID: ${{ secrets.AZURE_UAMI_RESOURCE_ID }}
-          ACR_LOGIN_SERVER: ${{ vars.ACR_LOGIN_SERVER }}
-          AZURE_BLOB_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_BLOB_STORAGE_CONNECTION_STRING }}
-          AZURE_BLOB_STORAGE_BENCHMARK_CONTAINER: ${{ vars.AZURE_BLOB_STORAGE_BENCHMARK_CONTAINER }}
-          AZURE_BLOB_STORAGE_METADATA_CONTAINER: ${{ vars.AZURE_BLOB_STORAGE_METADATA_CONTAINER }}
-          POSTGRES_SERVER_NAME: ${{ vars.POSTGRES_SERVER_NAME }}
-          POSTGRES_USERNAME: ${{ secrets.POSTGRES_USERNAME }}
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-          AZURE_BLOB_STORAGE_ACCOUNT_KEY: ${{ secrets.AZURE_BLOB_STORAGE_ACCOUNT_KEY }}
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
-          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
-
+      - name: Delete Existing Orchestrator Container
         run: >
-          docker run --rm
-          -v "$HOME/.azure:/root/.azure"
-          -e AZURE_SUBSCRIPTION_ID
-          -e AZURE_UAMI_RESOURCE_ID
-          -e ACR_LOGIN_SERVER
-          -e AZURE_BLOB_STORAGE_CONNECTION_STRING
-          -e AZURE_BLOB_STORAGE_BENCHMARK_CONTAINER
-          -e AZURE_BLOB_STORAGE_METADATA_CONTAINER
-          -e POSTGRES_SERVER_NAME
-          -e POSTGRES_USERNAME
-          -e POSTGRES_PASSWORD
-          -e AZURE_BLOB_STORAGE_ACCOUNT_KEY
-          -e DATABRICKS_HOST
-          -e DATABRICKS_TOKEN
-          ${{ vars.ACR_LOGIN_SERVER }}/container-orchestrator:latest
+          az container delete
+          --resource-group ${{ vars.AZURE_RESOURCE_GROUP }}
+          --name ${{ vars.ACI_ORCHESTRATOR_NAME }}
+          --yes 2>/dev/null || true
+
+      - name: Create Orchestrator Container on ACI
+        run: >
+          az container create
+          --resource-group ${{ vars.AZURE_RESOURCE_GROUP }}
+          --name ${{ vars.ACI_ORCHESTRATOR_NAME }}
+          --image ${{ vars.ACR_LOGIN_SERVER }}/container-orchestrator:latest
+          --location ${{ vars.AZURE_RESOURCE_LOCATION }}
+          --cpu 2
+          --memory 2
+          --os-type Linux
+          --restart-policy Never
+          --assign-identity ${{ secrets.AZURE_UAMI_RESOURCE_ID }}
+          --registry-login-server ${{ vars.ACR_LOGIN_SERVER }}
+          --acr-identity ${{ secrets.AZURE_UAMI_RESOURCE_ID }}
+          --environment-variables
+          AZURE_SUBSCRIPTION_ID=${{ vars.AZURE_SUBSCRIPTION_ID }}
+          ACR_LOGIN_SERVER=${{ vars.ACR_LOGIN_SERVER }}
+          AZURE_BLOB_STORAGE_BENCHMARK_CONTAINER=${{ vars.AZURE_BLOB_STORAGE_BENCHMARK_CONTAINER }}
+          AZURE_BLOB_STORAGE_METADATA_CONTAINER=${{ vars.AZURE_BLOB_STORAGE_METADATA_CONTAINER }}
+          POSTGRES_SERVER_NAME=${{ vars.POSTGRES_SERVER_NAME }}
+          --secure-environment-variables
+          AZURE_UAMI_RESOURCE_ID=${{ secrets.AZURE_UAMI_RESOURCE_ID }}
+          AZURE_BLOB_STORAGE_CONNECTION_STRING=${{ secrets.AZURE_BLOB_STORAGE_CONNECTION_STRING }}
+          AZURE_BLOB_STORAGE_ACCOUNT_KEY=${{ secrets.AZURE_BLOB_STORAGE_ACCOUNT_KEY }}
+          POSTGRES_USERNAME=${{ secrets.POSTGRES_USERNAME }}
+          POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+          DATABRICKS_HOST=${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_TOKEN=${{ secrets.DATABRICKS_TOKEN }}
+          --no-wait


### PR DESCRIPTION
This pull request updates the benchmark workflow to improve how the orchestrator container is managed and to reduce the frequency of scheduled runs. The workflow now uses Azure Container Instances (ACI) instead of running the orchestrator via Docker, and it ensures the orchestrator container is deleted before being recreated. Additionally, the scheduled benchmark runs are now set to occur weekly instead of daily.

**Benchmark workflow improvements:**

* Changed the scheduled benchmark run from daily to weekly by updating the cron schedule to run only on Mondays.

* Replaced the Docker-based orchestrator container workflow with Azure Container Instances (ACI):
  - Removed steps for logging in to Azure Container Registry (ACR), pulling the orchestrator image, and running the container with Docker.
  - Added a step to delete any existing orchestrator container in ACI before creating a new one, ensuring a clean environment for each run.
  - Added a step to create the orchestrator container directly in ACI, passing required environment and secure variables, and using managed identities for authentication.