### PR TITLE
#210 Changed environment variables

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Delete Existing Orchestrator Container
         run: |
           az container delete \
-            --resource-group ${{ vars.AZURE_RESOURCE_GROUP }} \
-            --name ${{ vars.ACI_ORCHESTRATOR_NAME }} \
+            --resource-group doppa \
+            --name container-orchestrator \
             --yes 2>/dev/null || true
 
       - name: Create Orchestrator Container on ACI
@@ -46,10 +46,10 @@ jobs:
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
         run: |
           az container create \
-            --resource-group ${{ vars.AZURE_RESOURCE_GROUP }} \
-            --name ${{ vars.ACI_ORCHESTRATOR_NAME }} \
+            --resource-group doppa \
+            --name container-orchestrator \
             --image ${{ vars.ACR_LOGIN_SERVER }}/container-orchestrator:latest \
-            --location ${{ vars.AZURE_RESOURCE_LOCATION }} \
+            --location norwayeast \
             --cpu 2 \
             --memory 2 \
             --os-type Linux \


### PR DESCRIPTION
This pull request updates the Azure resource group, container name, and location used in the GitHub Actions workflow for running benchmarks. The changes hardcode these values instead of using workflow variables.

**Workflow configuration changes:**

* Updated the resource group from the variable `${{ vars.AZURE_RESOURCE_GROUP }}` to the hardcoded value `doppa` in both the container deletion and creation steps in `.github/workflows/run-benchmarks.yml`. [[1]](diffhunk://#diff-00107fb05307cc943b796fe04be904eaec8aaeacd416c00a9fc3d0ed281f25b7L34-R35) [[2]](diffhunk://#diff-00107fb05307cc943b796fe04be904eaec8aaeacd416c00a9fc3d0ed281f25b7L49-R52)
* Updated the container name from the variable `${{ vars.ACI_ORCHESTRATOR_NAME }}` to the hardcoded value `container-orchestrator` in both steps. [[1]](diffhunk://#diff-00107fb05307cc943b796fe04be904eaec8aaeacd416c00a9fc3d0ed281f25b7L34-R35) [[2]](diffhunk://#diff-00107fb05307cc943b796fe04be904eaec8aaeacd416c00a9fc3d0ed281f25b7L49-R52)
* Changed the location from the variable `${{ vars.AZURE_RESOURCE_LOCATION }}` to the hardcoded value `norwayeast` in the container creation step.