### PR TITLE
Bugfix/224 gdal not installed on query containers

### DIFF
--- a/.docker/Query.Dockerfile
+++ b/.docker/Query.Dockerfile
@@ -4,7 +4,10 @@ COPY requirements.txt /app/
 RUN apt-get update && apt-get install -y \
     libexpat1 \
     libgdal-dev \
+    g++ \
     && pip install --no-cache-dir gdal==$(gdal-config --version) \
+    && apt-get purge -y g++ \
+    && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . /app

--- a/.docker/Query.Dockerfile
+++ b/.docker/Query.Dockerfile
@@ -1,6 +1,10 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt /app/
-RUN apt-get update && apt-get install -y libexpat1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y \
+    libexpat1 \
+    libgdal-dev \
+    && pip install --no-cache-dir gdal==$(gdal-config --version) \
+    && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . /app


### PR DESCRIPTION
This pull request updates the `.docker/Query.Dockerfile` to improve support for GDAL and its Python bindings. The changes ensure that the correct version of the `gdal` Python package is installed to match the system libraries, and unnecessary build dependencies are removed after installation to keep the image slim.

**Dockerfile improvements for GDAL support:**

* Added installation of `libgdal-dev` and `g++` to provide necessary system libraries and compiler for building the `gdal` Python package.
* Installed the `gdal` Python package using `pip`, explicitly matching the version to the system `gdal` library (`gdal-config --version`) for compatibility.
* Removed build dependencies (`g++`) and cleaned up unused packages after installation to reduce image size.