### PR TITLE
#228 Added DATABRICKS_HOST and DATABRICKS_TOKEN as env vars

### DIFF
--- a/main.py
+++ b/main.py
@@ -240,6 +240,8 @@ def _create_container_instance(
         f"AZURE_BLOB_STORAGE_CONNECTION_STRING={Config.AZURE_BLOB_STORAGE_CONNECTION_STRING}",
         f"POSTGRES_USERNAME={Config.POSTGRES_USERNAME}",
         f"POSTGRES_PASSWORD={Config.POSTGRES_PASSWORD}",
+        f"DATABRICKS_HOST={Config.DATABRICKS_HOST}",
+        f"DATABRICKS_TOKEN={Config.DATABRICKS_TOKEN}",
         "--no-wait",
     ]
 


### PR DESCRIPTION
This pull request makes a small update to the container instance creation logic in `main.py` by adding two new environment variables for Databricks configuration.

- Added support for Databricks integration:
  * Included `DATABRICKS_HOST` and `DATABRICKS_TOKEN` as environment variables when creating the container instance in `_create_container_instance` (`main.py`).