### PR TITLE
#230 Added blob storage account key as env var

### DIFF
--- a/main.py
+++ b/main.py
@@ -242,6 +242,7 @@ def _create_container_instance(
         f"POSTGRES_PASSWORD={Config.POSTGRES_PASSWORD}",
         f"DATABRICKS_HOST={Config.DATABRICKS_HOST}",
         f"DATABRICKS_TOKEN={Config.DATABRICKS_TOKEN}",
+        f"AZURE_BLOB_STORAGE_ACCOUNT_KEY={Config.AZURE_BLOB_STORAGE_ACCOUNT_KEY}",
         "--no-wait",
     ]
 


### PR DESCRIPTION
This pull request makes a minor update to the `_create_container_instance` function in `main.py` by adding the `AZURE_BLOB_STORAGE_ACCOUNT_KEY` environment variable to the container configuration. This ensures that the container has the necessary credentials to access Azure Blob Storage.