### PR TITLE
#234 Installed missing deps for GDAL

### DIFF
--- a/.docker/Api.Dockerfile
+++ b/.docker/Api.Dockerfile
@@ -1,7 +1,14 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt /app/
-RUN apt-get update && apt-get install -y libexpat1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y \
+    libexpat1 \
+    libgdal-dev \
+    g++ \
+    && pip install --no-cache-dir gdal==$(gdal-config --version) \
+    && apt-get purge -y g++ \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . /app
 


### PR DESCRIPTION
This pull request updates the `.docker/Api.Dockerfile` to add support for the `gdal` library and its dependencies, which are often required for geospatial data processing in Python applications.

**Dependency and build environment updates:**

* Added installation of `libgdal-dev` and `g++` to allow building and installing the `gdal` Python package, and ensured the exact version of `gdal` matching the system library is installed. (`.docker/Api.Dockerfile`)
* Cleaned up the Docker image by removing build dependencies (`g++`) after installation and running `apt-get autoremove` to keep the image size small. (`.docker/Api.Dockerfile`)