### PR TITLE
#275 Wire RQ1/RQ2 benchmark matrix

### DIFF
--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -140,68 +140,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - service: db-scan-blob-storage
-            display_name: Blob Storage DB Scan
+          # ---- RQ1 query benchmarks ----
+          - service: point-in-polygon-lookup-duckdb
+            display_name: DuckDB Point-in-Polygon Lookup
 
-          - service: db-scan-postgis
-            display_name: PostGIS DB Scan
+          - service: point-in-polygon-lookup-postgis
+            display_name: PostGIS Point-in-Polygon Lookup
 
-          - service: bbox-filtering-advanced-duckdb
-            display_name: Advanced DuckDB Bounding Box Filtering
-
-          - service: bbox-filtering-advanced-postgis
-            display_name: Advanced PostGIS Bounding Box Filtering
-
-          - service: bbox-filtering-simple-local
-            display_name: Simple Shapefile Bounding Box Filtering
-
-          - service: bbox-filtering-simple-blob-storage
-            display_name: Simple GeoParquet Bounding Box Filtering
-
-          - service: bbox-filtering-result-set-sizes-neighborhood-duckdb
-            display_name: Neighborhood DuckDB Bounding Box Filtering Result Set Sizes
-
-          - service: bbox-filtering-result-set-sizes-municipality-duckdb
-            display_name: Municipality DuckDB Bounding Box Filtering Result Set Sizes
-
-          - service: bbox-filtering-result-set-sizes-county-duckdb
-            display_name: County DuckDB Bounding Box Filtering Result Set Sizes
-
-          - service: bbox-filtering-result-set-sizes-neighborhood-postgis
-            display_name: Neighborhood PostGIS Bounding Box Filtering Result Set Sizes
-
-          - service: bbox-filtering-result-set-sizes-municipality-postgis
-            display_name: Municipality PostGIS Bounding Box Filtering Result Set Sizes
-
-          - service: bbox-filtering-result-set-sizes-county-postgis
-            display_name: County PostGIS Bounding Box Filtering Result Set Sizes
-
-          - service: bbox-filtering-result-set-sizes-neighborhood-local
-            display_name: Neighborhood Local Bounding Box Filtering Result Set Sizes
-
-          - service: bbox-filtering-result-set-sizes-municipality-local
-            display_name: Municipality Local Bounding Box Filtering Result Set Sizes
-
-          - service: bbox-filtering-result-set-sizes-county-local
-            display_name: County Local Bounding Box Filtering Result Set Sizes
-
-          - service: vector-tiles-single-tile-pmtiles
-            display_name: PMTiles Fetch Single Tile
-
-          - service: vector-tiles-single-tile-vmt
-            display_name: VMT Fetch Single Tile
-
-          - service: vector-tiles-100k-pmtiles
-            display_name: PMTiles Fetch 100 000 Tiles
-
-          - service: vector-tiles-100k-vmt
-            display_name: VMT Fetch 100 000 Tiles
-
-          - service: spatial-aggregation-grid-duckdb
-            display_name: DuckDB Spatial Aggregation by Grid Cell
-
-          - service: spatial-aggregation-grid-postgis
-            display_name: PostGIS Spatial Aggregation by Grid Cell
+          - service: point-in-polygon-lookup-local
+            display_name: Shapefile Point-in-Polygon Lookup
 
           - service: attribute-spatial-compound-filter-duckdb
             display_name: DuckDB Attribute + Spatial Compound Filter
@@ -209,32 +156,105 @@ jobs:
           - service: attribute-spatial-compound-filter-postgis
             display_name: PostGIS Attribute + Spatial Compound Filter
 
-          - service: ordered-range-query-duckdb
-            display_name: DuckDB Ordered Range Query with LIMIT
+          - service: attribute-spatial-compound-filter-local
+            display_name: Shapefile Attribute + Spatial Compound Filter
 
-          - service: ordered-range-query-postgis
-            display_name: PostGIS Ordered Range Query with LIMIT
+          - service: knn-search-duckdb
+            display_name: DuckDB KNN Search
 
-          - service: point-in-polygon-lookup-duckdb
-            display_name: DuckDB Point-in-Polygon Lookup
+          - service: knn-search-postgis
+            display_name: PostGIS KNN Search
 
-          - service: point-in-polygon-lookup-postgis
-            display_name: PostGIS Point-in-Polygon Lookup
+          - service: knn-search-local
+            display_name: Shapefile KNN Search
 
+          - service: bbox-filtering-duckdb
+            display_name: DuckDB Bounding Box Filtering
+
+          - service: bbox-filtering-postgis
+            display_name: PostGIS Bounding Box Filtering
+
+          - service: bbox-filtering-local
+            display_name: Shapefile Bounding Box Filtering
+
+          # ---- RQ2 national-scale spatial join ----
           - service: national-scale-spatial-join-duckdb
             display_name: DuckDB National Scale Spatial Join
 
           - service: national-scale-spatial-join-postgis
             display_name: PostGIS National Scale Spatial Join
 
-          - service: national-scale-spatial-join-databricks-2-nodes
-            display_name: Databricks National Scale Spatial Join - 2 Nodes
+          - service: national-scale-spatial-join-databricks-broadcast-2-nodes
+            display_name: Sedona National Scale Spatial Join - Broadcast - 2 Nodes
 
-          - service: national-scale-spatial-join-databricks-4-nodes
-            display_name: Databricks National Scale Spatial Join - 4 Nodes
+          - service: national-scale-spatial-join-databricks-broadcast-4-nodes
+            display_name: Sedona National Scale Spatial Join - Broadcast - 4 Nodes
 
-          - service: national-scale-spatial-join-databricks-8-nodes
-            display_name: Databricks National Scale Spatial Join - 8 Nodes
+          - service: national-scale-spatial-join-databricks-broadcast-8-nodes
+            display_name: Sedona National Scale Spatial Join - Broadcast - 8 Nodes
+
+          - service: national-scale-spatial-join-databricks-partitioned-2-nodes
+            display_name: Sedona National Scale Spatial Join - Partitioned - 2 Nodes
+
+          - service: national-scale-spatial-join-databricks-partitioned-4-nodes
+            display_name: Sedona National Scale Spatial Join - Partitioned - 4 Nodes
+
+          - service: national-scale-spatial-join-databricks-partitioned-8-nodes
+            display_name: Sedona National Scale Spatial Join - Partitioned - 8 Nodes
+
+          # ---- Out-of-scope (kept commented for easy re-enable) ----
+          # - service: db-scan-blob-storage
+          #   display_name: Blob Storage DB Scan
+          # - service: db-scan-postgis
+          #   display_name: PostGIS DB Scan
+          # - service: bbox-filtering-advanced-duckdb
+          #   display_name: Advanced DuckDB Bounding Box Filtering
+          # - service: bbox-filtering-advanced-postgis
+          #   display_name: Advanced PostGIS Bounding Box Filtering
+          # - service: bbox-filtering-simple-local
+          #   display_name: Simple Shapefile Bounding Box Filtering
+          # - service: bbox-filtering-simple-blob-storage
+          #   display_name: Simple GeoParquet Bounding Box Filtering
+          # - service: bbox-filtering-result-set-sizes-neighborhood-duckdb
+          #   display_name: Neighborhood DuckDB Bounding Box Filtering Result Set Sizes
+          # - service: bbox-filtering-result-set-sizes-municipality-duckdb
+          #   display_name: Municipality DuckDB Bounding Box Filtering Result Set Sizes
+          # - service: bbox-filtering-result-set-sizes-county-duckdb
+          #   display_name: County DuckDB Bounding Box Filtering Result Set Sizes
+          # - service: bbox-filtering-result-set-sizes-neighborhood-postgis
+          #   display_name: Neighborhood PostGIS Bounding Box Filtering Result Set Sizes
+          # - service: bbox-filtering-result-set-sizes-municipality-postgis
+          #   display_name: Municipality PostGIS Bounding Box Filtering Result Set Sizes
+          # - service: bbox-filtering-result-set-sizes-county-postgis
+          #   display_name: County PostGIS Bounding Box Filtering Result Set Sizes
+          # - service: bbox-filtering-result-set-sizes-neighborhood-local
+          #   display_name: Neighborhood Local Bounding Box Filtering Result Set Sizes
+          # - service: bbox-filtering-result-set-sizes-municipality-local
+          #   display_name: Municipality Local Bounding Box Filtering Result Set Sizes
+          # - service: bbox-filtering-result-set-sizes-county-local
+          #   display_name: County Local Bounding Box Filtering Result Set Sizes
+          # - service: vector-tiles-single-tile-pmtiles
+          #   display_name: PMTiles Fetch Single Tile
+          # - service: vector-tiles-single-tile-vmt
+          #   display_name: VMT Fetch Single Tile
+          # - service: vector-tiles-100k-pmtiles
+          #   display_name: PMTiles Fetch 100 000 Tiles
+          # - service: vector-tiles-100k-vmt
+          #   display_name: VMT Fetch 100 000 Tiles
+          # - service: spatial-aggregation-grid-duckdb
+          #   display_name: DuckDB Spatial Aggregation by Grid Cell
+          # - service: spatial-aggregation-grid-postgis
+          #   display_name: PostGIS Spatial Aggregation by Grid Cell
+          # - service: ordered-range-query-duckdb
+          #   display_name: DuckDB Ordered Range Query with LIMIT
+          # - service: ordered-range-query-postgis
+          #   display_name: PostGIS Ordered Range Query with LIMIT
+          # - service: national-scale-spatial-join-databricks-2-nodes
+          #   display_name: Databricks National Scale Spatial Join - 2 Nodes
+          # - service: national-scale-spatial-join-databricks-4-nodes
+          #   display_name: Databricks National Scale Spatial Join - 4 Nodes
+          # - service: national-scale-spatial-join-databricks-8-nodes
+          #   display_name: Databricks National Scale Spatial Join - 8 Nodes
 
     steps:
       - name: Checkout code

--- a/.github/workflows/push-containers-to-acr.yml
+++ b/.github/workflows/push-containers-to-acr.yml
@@ -59,89 +59,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - service: db-scan-blob-storage
-            image: db-scan-blob-storage
-            display_name: Blob Storage DB Scan
+          # ---- RQ1 query benchmarks ----
+          - service: point-in-polygon-lookup-duckdb
+            image: point-in-polygon-lookup-duckdb
+            display_name: DuckDB Point-in-Polygon Lookup
 
-          - service: db-scan-postgis
-            image: db-scan-postgis
-            display_name: PostGIS DB Scan
+          - service: point-in-polygon-lookup-postgis
+            image: point-in-polygon-lookup-postgis
+            display_name: PostGIS Point-in-Polygon Lookup
 
-          - service: bbox-filtering-advanced-duckdb
-            image: bbox-filtering-advanced-duckdb
-            display_name: Advanced DuckDB Bounding Box Filtering
-
-          - service: bbox-filtering-advanced-postgis
-            image: bbox-filtering-advanced-postgis
-            display_name: Advanced PostGIS Bounding Box Filtering
-
-          - service: bbox-filtering-simple-local
-            image: bbox-filtering-simple-local
-            display_name: Simple Shapefile Bounding Box Filtering
-
-          - service: bbox-filtering-simple-blob-storage
-            image: bbox-filtering-simple-blob-storage
-            display_name: Simple GeoParquet Bounding Box Filtering
-
-          - service: bbox-filtering-result-set-sizes-neighborhood-duckdb
-            image: bbox-filtering-result-set-sizes-neighborhood-duckdb
-            display_name: DuckDB Bounding Box Filtering - Neighborhood
-
-          - service: bbox-filtering-result-set-sizes-municipality-duckdb
-            image: bbox-filtering-result-set-sizes-municipality-duckdb
-            display_name: DuckDB Bounding Box Filtering - Municipality
-
-          - service: bbox-filtering-result-set-sizes-county-duckdb
-            image: bbox-filtering-result-set-sizes-county-duckdb
-            display_name: DuckDB Bounding Box Filtering - County
-
-          - service: bbox-filtering-result-set-sizes-neighborhood-postgis
-            image: bbox-filtering-result-set-sizes-neighborhood-postgis
-            display_name: PostGIS Bounding Box Filtering - Neighborhood
-
-          - service: bbox-filtering-result-set-sizes-municipality-postgis
-            image: bbox-filtering-result-set-sizes-municipality-postgis
-            display_name: PostGIS Bounding Box Filtering - Municipality
-
-          - service: bbox-filtering-result-set-sizes-county-postgis
-            image: bbox-filtering-result-set-sizes-county-postgis
-            display_name: PostGIS Bounding Box Filtering - County
-
-          - service: bbox-filtering-result-set-sizes-neighborhood-local
-            image: bbox-filtering-result-set-sizes-neighborhood-local
-            display_name: Shapefile Bounding Box Filtering - Neighborhood
-
-          - service: bbox-filtering-result-set-sizes-municipality-local
-            image: bbox-filtering-result-set-sizes-municipality-local
-            display_name: Shapefile Bounding Box Filtering - Municipality
-
-          - service: bbox-filtering-result-set-sizes-county-local
-            image: bbox-filtering-result-set-sizes-county-local
-            display_name: Shapefile Bounding Box Filtering - County
-
-          - service: vector-tiles-single-tile-pmtiles
-            image: vector-tiles-single-tile-pmtiles
-            display_name: PMTiles Fetch Single Tile
-
-          - service: vector-tiles-single-tile-vmt
-            image: vector-tiles-single-tile-vmt
-            display_name: VMT Fetch Single Tile
-
-          - service: vector-tiles-100k-pmtiles
-            image: vector-tiles-100k-pmtiles
-            display_name: PMTiles Fetch 100 000 Tiles
-
-          - service: vector-tiles-100k-vmt
-            image: vector-tiles-100k-vmt
-            display_name: VMT Fetch 100 000 Tiles
-
-          - service: spatial-aggregation-grid-duckdb
-            image: spatial-aggregation-grid-duckdb
-            display_name: DuckDB Spatial Aggregation by Grid Cell
-
-          - service: spatial-aggregation-grid-postgis
-            image: spatial-aggregation-grid-postgis
-            display_name: PostGIS Spatial Aggregation by Grid Cell
+          - service: point-in-polygon-lookup-local
+            image: point-in-polygon-lookup-local
+            display_name: Shapefile Point-in-Polygon Lookup
 
           - service: attribute-spatial-compound-filter-duckdb
             image: attribute-spatial-compound-filter-duckdb
@@ -151,22 +80,35 @@ jobs:
             image: attribute-spatial-compound-filter-postgis
             display_name: PostGIS Attribute + Spatial Compound Filter
 
-          - service: ordered-range-query-duckdb
-            image: ordered-range-query-duckdb
-            display_name: DuckDB Ordered Range Query with LIMIT
+          - service: attribute-spatial-compound-filter-local
+            image: attribute-spatial-compound-filter-local
+            display_name: Shapefile Attribute + Spatial Compound Filter
 
-          - service: ordered-range-query-postgis
-            image: ordered-range-query-postgis
-            display_name: PostGIS Ordered Range Query with LIMIT
+          - service: knn-search-duckdb
+            image: knn-search-duckdb
+            display_name: DuckDB KNN Search
 
-          - service: point-in-polygon-lookup-duckdb
-            image: point-in-polygon-lookup-duckdb
-            display_name: DuckDB Point-in-Polygon Lookup
+          - service: knn-search-postgis
+            image: knn-search-postgis
+            display_name: PostGIS KNN Search
 
-          - service: point-in-polygon-lookup-postgis
-            image: point-in-polygon-lookup-postgis
-            display_name: PostGIS Point-in-Polygon Lookup
+          - service: knn-search-local
+            image: knn-search-local
+            display_name: Shapefile KNN Search
 
+          - service: bbox-filtering-duckdb
+            image: bbox-filtering-duckdb
+            display_name: DuckDB Bounding Box Filtering
+
+          - service: bbox-filtering-postgis
+            image: bbox-filtering-postgis
+            display_name: PostGIS Bounding Box Filtering
+
+          - service: bbox-filtering-local
+            image: bbox-filtering-local
+            display_name: Shapefile Bounding Box Filtering
+
+          # ---- RQ2 national-scale spatial join ----
           - service: national-scale-spatial-join-duckdb
             image: national-scale-spatial-join-duckdb
             display_name: DuckDB National Scale Spatial Join
@@ -175,17 +117,109 @@ jobs:
             image: national-scale-spatial-join-postgis
             display_name: PostGIS National Scale Spatial Join
 
-          - service: national-scale-spatial-join-databricks-2-nodes
-            image: national-scale-spatial-join-databricks-2-nodes
-            display_name: Databricks National Scale Spatial Join - 2 Nodes
+          - service: national-scale-spatial-join-databricks-broadcast-2-nodes
+            image: national-scale-spatial-join-databricks-broadcast-2-nodes
+            display_name: Sedona National Scale Spatial Join - Broadcast - 2 Nodes
 
-          - service: national-scale-spatial-join-databricks-4-nodes
-            image: national-scale-spatial-join-databricks-4-nodes
-            display_name: Databricks National Scale Spatial Join - 4 Nodes
+          - service: national-scale-spatial-join-databricks-broadcast-4-nodes
+            image: national-scale-spatial-join-databricks-broadcast-4-nodes
+            display_name: Sedona National Scale Spatial Join - Broadcast - 4 Nodes
 
-          - service: national-scale-spatial-join-databricks-8-nodes
-            image: national-scale-spatial-join-databricks-8-nodes
-            display_name: Databricks National Scale Spatial Join - 8 Nodes
+          - service: national-scale-spatial-join-databricks-broadcast-8-nodes
+            image: national-scale-spatial-join-databricks-broadcast-8-nodes
+            display_name: Sedona National Scale Spatial Join - Broadcast - 8 Nodes
+
+          - service: national-scale-spatial-join-databricks-partitioned-2-nodes
+            image: national-scale-spatial-join-databricks-partitioned-2-nodes
+            display_name: Sedona National Scale Spatial Join - Partitioned - 2 Nodes
+
+          - service: national-scale-spatial-join-databricks-partitioned-4-nodes
+            image: national-scale-spatial-join-databricks-partitioned-4-nodes
+            display_name: Sedona National Scale Spatial Join - Partitioned - 4 Nodes
+
+          - service: national-scale-spatial-join-databricks-partitioned-8-nodes
+            image: national-scale-spatial-join-databricks-partitioned-8-nodes
+            display_name: Sedona National Scale Spatial Join - Partitioned - 8 Nodes
+
+          # ---- Out-of-scope (kept commented for easy re-enable) ----
+          # - service: db-scan-blob-storage
+          #   image: db-scan-blob-storage
+          #   display_name: Blob Storage DB Scan
+          # - service: db-scan-postgis
+          #   image: db-scan-postgis
+          #   display_name: PostGIS DB Scan
+          # - service: bbox-filtering-advanced-duckdb
+          #   image: bbox-filtering-advanced-duckdb
+          #   display_name: Advanced DuckDB Bounding Box Filtering
+          # - service: bbox-filtering-advanced-postgis
+          #   image: bbox-filtering-advanced-postgis
+          #   display_name: Advanced PostGIS Bounding Box Filtering
+          # - service: bbox-filtering-simple-local
+          #   image: bbox-filtering-simple-local
+          #   display_name: Simple Shapefile Bounding Box Filtering
+          # - service: bbox-filtering-simple-blob-storage
+          #   image: bbox-filtering-simple-blob-storage
+          #   display_name: Simple GeoParquet Bounding Box Filtering
+          # - service: bbox-filtering-result-set-sizes-neighborhood-duckdb
+          #   image: bbox-filtering-result-set-sizes-neighborhood-duckdb
+          #   display_name: DuckDB Bounding Box Filtering - Neighborhood
+          # - service: bbox-filtering-result-set-sizes-municipality-duckdb
+          #   image: bbox-filtering-result-set-sizes-municipality-duckdb
+          #   display_name: DuckDB Bounding Box Filtering - Municipality
+          # - service: bbox-filtering-result-set-sizes-county-duckdb
+          #   image: bbox-filtering-result-set-sizes-county-duckdb
+          #   display_name: DuckDB Bounding Box Filtering - County
+          # - service: bbox-filtering-result-set-sizes-neighborhood-postgis
+          #   image: bbox-filtering-result-set-sizes-neighborhood-postgis
+          #   display_name: PostGIS Bounding Box Filtering - Neighborhood
+          # - service: bbox-filtering-result-set-sizes-municipality-postgis
+          #   image: bbox-filtering-result-set-sizes-municipality-postgis
+          #   display_name: PostGIS Bounding Box Filtering - Municipality
+          # - service: bbox-filtering-result-set-sizes-county-postgis
+          #   image: bbox-filtering-result-set-sizes-county-postgis
+          #   display_name: PostGIS Bounding Box Filtering - County
+          # - service: bbox-filtering-result-set-sizes-neighborhood-local
+          #   image: bbox-filtering-result-set-sizes-neighborhood-local
+          #   display_name: Shapefile Bounding Box Filtering - Neighborhood
+          # - service: bbox-filtering-result-set-sizes-municipality-local
+          #   image: bbox-filtering-result-set-sizes-municipality-local
+          #   display_name: Shapefile Bounding Box Filtering - Municipality
+          # - service: bbox-filtering-result-set-sizes-county-local
+          #   image: bbox-filtering-result-set-sizes-county-local
+          #   display_name: Shapefile Bounding Box Filtering - County
+          # - service: vector-tiles-single-tile-pmtiles
+          #   image: vector-tiles-single-tile-pmtiles
+          #   display_name: PMTiles Fetch Single Tile
+          # - service: vector-tiles-single-tile-vmt
+          #   image: vector-tiles-single-tile-vmt
+          #   display_name: VMT Fetch Single Tile
+          # - service: vector-tiles-100k-pmtiles
+          #   image: vector-tiles-100k-pmtiles
+          #   display_name: PMTiles Fetch 100 000 Tiles
+          # - service: vector-tiles-100k-vmt
+          #   image: vector-tiles-100k-vmt
+          #   display_name: VMT Fetch 100 000 Tiles
+          # - service: spatial-aggregation-grid-duckdb
+          #   image: spatial-aggregation-grid-duckdb
+          #   display_name: DuckDB Spatial Aggregation by Grid Cell
+          # - service: spatial-aggregation-grid-postgis
+          #   image: spatial-aggregation-grid-postgis
+          #   display_name: PostGIS Spatial Aggregation by Grid Cell
+          # - service: ordered-range-query-duckdb
+          #   image: ordered-range-query-duckdb
+          #   display_name: DuckDB Ordered Range Query with LIMIT
+          # - service: ordered-range-query-postgis
+          #   image: ordered-range-query-postgis
+          #   display_name: PostGIS Ordered Range Query with LIMIT
+          # - service: national-scale-spatial-join-databricks-2-nodes
+          #   image: national-scale-spatial-join-databricks-2-nodes
+          #   display_name: Databricks National Scale Spatial Join - 2 Nodes
+          # - service: national-scale-spatial-join-databricks-4-nodes
+          #   image: national-scale-spatial-join-databricks-4-nodes
+          #   display_name: Databricks National Scale Spatial Join - 4 Nodes
+          # - service: national-scale-spatial-join-databricks-8-nodes
+          #   image: national-scale-spatial-join-databricks-8-nodes
+          #   display_name: Databricks National Scale Spatial Join - 8 Nodes
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ measurable and reproducible on identical datasets and hardware.
     - [Engines under test](#engines-under-test)
     - [Databricks cluster lifecycle](#databricks-cluster-lifecycle)
     - [Pairing and randomization](#pairing-and-randomization)
+    - [Test matrix](#test-matrix)
 - [Dataset layout](#dataset-layout)
     - [Sizes and synthesis](#sizes-and-synthesis)
     - [Postgres tables](#postgres-tables)
@@ -146,10 +147,44 @@ sample so the distributed runtime can be decomposed into read, shuffle, and driv
 ### Pairing and randomization
 
 `main.py` shuffles the experiment list with `random.Random(benchmark_run)` before launching containers. Experiments
-that compare directly (for example `db-scan-blob-storage` and `db-scan-postgis`) declare each other under
-`related_script_ids` in `benchmarks.yml` and are launched concurrently via a `ThreadPoolExecutor`. Running a paired
-benchmark in the same wall-clock window controls for short-term cloud variability between the two engines being
-compared.
+that compare directly (for example `point-in-polygon-lookup-duckdb-small` and `point-in-polygon-lookup-postgis-small`)
+declare each other under `related_script_ids` in `benchmarks.yml` and are launched concurrently via a
+`ThreadPoolExecutor`. Running a paired benchmark in the same wall-clock window controls for short-term cloud
+variability between the engines being compared.
+
+Concretely, the outer orchestrator loop is serial: it picks the next experiment that has not yet completed, fans out
+its pair group as one parallel batch, waits for the whole batch to finish, marks every member completed, and moves on.
+At any moment one pair group is in flight; within that group every member runs on its own ACI in parallel.
+
+### Test matrix
+
+The matrix below is the active set of 52 experiments grouped into 33 parallel pair groups. Each cell lists the
+engines that launch together in the same wall-clock window; size suffixes (`-small`, `-medium`, `-large`) are
+appended to the experiment ids in `benchmarks.yml` and forwarded to each container as `--dataset-size`. Shapefile
+(`local`) only participates at the `small` tier per the thesis methodology — it represents the laptop-workflow
+reference, not a scalable engine.
+
+**RQ1 — Single-machine query benchmarks** (28 experiments, 12 pair groups)
+
+| Query type                         | `small` (3-way)              | `medium` (2-way) | `large` (2-way)  |
+|------------------------------------|------------------------------|------------------|------------------|
+| `point-in-polygon-lookup`          | duckdb · postgis · local     | duckdb · postgis | duckdb · postgis |
+| `attribute-spatial-compound-filter`| duckdb · postgis · local     | duckdb · postgis | duckdb · postgis |
+| `knn-search`                       | duckdb · postgis · local     | duckdb · postgis | duckdb · postgis |
+| `bbox-filtering`                   | duckdb · postgis · local     | duckdb · postgis | duckdb · postgis |
+
+**RQ2 — National-scale spatial join** (24 experiments, 21 pair groups)
+
+| Engine / strategy                       | `small`                  | `medium`                 | `large`                  |
+|-----------------------------------------|--------------------------|--------------------------|--------------------------|
+| Single-node (paired)                    | duckdb · postgis         | duckdb · postgis         | duckdb · postgis         |
+| Sedona `broadcast` (unpaired)           | 2 nodes / 4 nodes / 8 nodes | 2 nodes / 4 nodes / 8 nodes | 2 nodes / 4 nodes / 8 nodes |
+| Sedona `partitioned` (unpaired)         | 2 nodes / 4 nodes / 8 nodes | 2 nodes / 4 nodes / 8 nodes | 2 nodes / 4 nodes / 8 nodes |
+
+Cells in the **paired** rows list every engine that launches in the same wall-clock window (one ACI each, started
+concurrently via `ThreadPoolExecutor`). Cells in the **unpaired** rows list separate experiments that each run alone
+in their own pair group — they share a row only because they share a strategy/size, not because they co-launch.
+Sedona variants are unpaired because each provisions its own Databricks cluster.
 
 ## Dataset layout
 

--- a/benchmark_runner.py
+++ b/benchmark_runner.py
@@ -60,7 +60,7 @@ def benchmark_runner() -> None:
         run_id=run_id, benchmark_run=benchmark_run, dataset_size=dataset_size
     )
 
-    match script_id:
+    match _strip_dataset_size_suffix(script_id):
         case "db-scan-blob-storage":
             db_scan_blob_storage()
             return
@@ -186,6 +186,20 @@ def benchmark_runner() -> None:
             return
         case _:
             raise ValueError("Script ID is invalid")
+
+
+def _strip_dataset_size_suffix(script_id: str) -> str:
+    """
+    Strip a trailing ``-{size}`` suffix from ``script_id`` so that experiment ids
+    like ``point-in-polygon-lookup-duckdb-medium`` dispatch to the same entrypoint
+    as the base id ``point-in-polygon-lookup-duckdb``. Size differentiation
+    happens via the ``--dataset-size`` runtime arg, not the dispatch key.
+    """
+    for size in DatasetSize:
+        suffix = f"-{size.value}"
+        if script_id.endswith(suffix):
+            return script_id[: -len(suffix)]
+    return script_id
 
 
 def _get_args() -> tuple[str, int, Optional[str], DatasetSize]:

--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -1,342 +1,471 @@
 experiments:
-  - id: db-scan-blob-storage
-    image: doppaacr.azurecr.io/db-scan-blob-storage:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids: ["db-scan-postgis"]
+  # ==================================================================
+  # RQ1 — Single-machine query benchmarks (28 experiments)
+  # 4 query types × (DuckDB + PostGIS at small/medium/large
+  #                  + Shapefile at small)
+  # Pairing: at `small` all three engines pair (3-way); at medium/large
+  # DuckDB and PostGIS pair (2-way). Shapefile only runs at small.
+  # ==================================================================
 
-  - id: db-scan-postgis
-    image: doppaacr.azurecr.io/db-scan-postgis:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids: ["db-scan-blob-storage"]
-
-  - id: bbox-filtering-advanced-duckdb
-    image: doppaacr.azurecr.io/bbox-filtering-advanced-duckdb:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids: ["bbox-filtering-advanced-postgis"]
-
-  - id: bbox-filtering-advanced-postgis
-    image: doppaacr.azurecr.io/bbox-filtering-advanced-postgis:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids: ["bbox-filtering-advanced-duckdb"]
-
-  - id: bbox-filtering-simple-local
-    image: doppaacr.azurecr.io/bbox-filtering-simple-local:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids: ["bbox-filtering-simple-blob-storage"]
-
-  - id: bbox-filtering-simple-blob-storage
-    image: doppaacr.azurecr.io/bbox-filtering-simple-blob-storage:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids: ["bbox-filtering-simple-local"]
-
-  - id: bbox-filtering-duckdb
-    image: doppaacr.azurecr.io/bbox-filtering-duckdb:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids:
-      [
-        "bbox-filtering-local",
-        "bbox-filtering-postgis",
-      ]
-
-  - id: bbox-filtering-result-set-sizes-municipality-duckdb
-    image: doppaacr.azurecr.io/bbox-filtering-result-set-sizes-municipality-duckdb:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids:
-      [
-        "bbox-filtering-result-set-sizes-municipality-local",
-        "bbox-filtering-result-set-sizes-municipality-postgis",
-      ]
-
-  - id: bbox-filtering-result-set-sizes-county-duckdb
-    image: doppaacr.azurecr.io/bbox-filtering-result-set-sizes-county-duckdb:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids:
-      [
-        "bbox-filtering-result-set-sizes-county-postgis",
-        "bbox-filtering-result-set-sizes-county-local",
-      ]
-
-  - id: bbox-filtering-postgis
-    image: doppaacr.azurecr.io/bbox-filtering-postgis:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids:
-      [
-        "bbox-filtering-local",
-        "bbox-filtering-duckdb",
-      ]
-
-  - id: bbox-filtering-result-set-sizes-municipality-postgis
-    image: doppaacr.azurecr.io/bbox-filtering-result-set-sizes-municipality-postgis:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids:
-      [
-        "bbox-filtering-result-set-sizes-municipality-local",
-        "bbox-filtering-result-set-sizes-municipality-duckdb",
-      ]
-
-  - id: bbox-filtering-result-set-sizes-county-postgis
-    image: doppaacr.azurecr.io/bbox-filtering-result-set-sizes-county-postgis:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids:
-      [
-        "bbox-filtering-result-set-sizes-county-local",
-        "bbox-filtering-result-set-sizes-county-duckdb",
-      ]
-
-  - id: bbox-filtering-local
-    image: doppaacr.azurecr.io/bbox-filtering-local:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids:
-      [
-        "bbox-filtering-duckdb",
-        "bbox-filtering-postgis",
-      ]
-
-  - id: bbox-filtering-result-set-sizes-municipality-local
-    image: doppaacr.azurecr.io/bbox-filtering-result-set-sizes-municipality-local:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids:
-      [
-        "bbox-filtering-result-set-sizes-municipality-duckdb",
-        "bbox-filtering-result-set-sizes-municipality-postgis",
-      ]
-
-  - id: bbox-filtering-result-set-sizes-county-local
-    image: doppaacr.azurecr.io/bbox-filtering-result-set-sizes-county-local:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids:
-      [
-        "bbox-filtering-result-set-sizes-county-duckdb",
-        "bbox-filtering-result-set-sizes-county-postgis",
-      ]
-
-  - id: vector-tiles-single-tile-pmtiles
-    image: doppaacr.azurecr.io/vector-tiles-single-tile-pmtiles:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids: ["vector-tiles-single-tile-vmt"]
-
-  - id: vector-tiles-single-tile-vmt
-    image: doppaacr.azurecr.io/vector-tiles-single-tile-vmt:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids: ["vector-tiles-single-tile-pmtiles"]
-
-  - id: spatial-aggregation-grid-duckdb
-    image: doppaacr.azurecr.io/spatial-aggregation-grid-duckdb:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids: ["spatial-aggregation-grid-postgis"]
-
-  - id: spatial-aggregation-grid-postgis
-    image: doppaacr.azurecr.io/spatial-aggregation-grid-postgis:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids: ["spatial-aggregation-grid-duckdb"]
-
-  - id: attribute-spatial-compound-filter-duckdb
-    image: doppaacr.azurecr.io/attribute-spatial-compound-filter-duckdb:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids:
-      [
-        "attribute-spatial-compound-filter-local",
-        "attribute-spatial-compound-filter-postgis",
-      ]
-
-  - id: attribute-spatial-compound-filter-local
-    image: doppaacr.azurecr.io/attribute-spatial-compound-filter-local:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids:
-      [
-        "attribute-spatial-compound-filter-duckdb",
-        "attribute-spatial-compound-filter-postgis",
-      ]
-
-  - id: attribute-spatial-compound-filter-postgis
-    image: doppaacr.azurecr.io/attribute-spatial-compound-filter-postgis:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids:
-      [
-        "attribute-spatial-compound-filter-duckdb",
-        "attribute-spatial-compound-filter-local",
-      ]
-
-  - id: ordered-range-query-duckdb
-    image: doppaacr.azurecr.io/ordered-range-query-duckdb:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids: ["ordered-range-query-postgis"]
-
-  - id: ordered-range-query-postgis
-    image: doppaacr.azurecr.io/ordered-range-query-postgis:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids: ["ordered-range-query-duckdb"]
-
-  - id: point-in-polygon-lookup-duckdb
+  # ---- point-in-polygon-lookup ----
+  - id: point-in-polygon-lookup-duckdb-small
     image: doppaacr.azurecr.io/point-in-polygon-lookup-duckdb:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
     related_script_ids:
-      [
-        "point-in-polygon-lookup-local",
-        "point-in-polygon-lookup-postgis",
-      ]
+      - point-in-polygon-lookup-postgis-small
+      - point-in-polygon-lookup-local-small
 
-  - id: point-in-polygon-lookup-local
-    image: doppaacr.azurecr.io/point-in-polygon-lookup-local:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids:
-      [
-        "point-in-polygon-lookup-duckdb",
-        "point-in-polygon-lookup-postgis",
-      ]
-
-  - id: point-in-polygon-lookup-postgis
+  - id: point-in-polygon-lookup-postgis-small
     image: doppaacr.azurecr.io/point-in-polygon-lookup-postgis:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
     related_script_ids:
-      [
-        "point-in-polygon-lookup-duckdb",
-        "point-in-polygon-lookup-local",
-      ]
+      - point-in-polygon-lookup-duckdb-small
+      - point-in-polygon-lookup-local-small
 
-  - id: knn-search-duckdb
+  - id: point-in-polygon-lookup-local-small
+    image: doppaacr.azurecr.io/point-in-polygon-lookup-local:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: small
+    related_script_ids:
+      - point-in-polygon-lookup-duckdb-small
+      - point-in-polygon-lookup-postgis-small
+
+  - id: point-in-polygon-lookup-duckdb-medium
+    image: doppaacr.azurecr.io/point-in-polygon-lookup-duckdb:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids:
+      - point-in-polygon-lookup-postgis-medium
+
+  - id: point-in-polygon-lookup-postgis-medium
+    image: doppaacr.azurecr.io/point-in-polygon-lookup-postgis:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids:
+      - point-in-polygon-lookup-duckdb-medium
+
+  - id: point-in-polygon-lookup-duckdb-large
+    image: doppaacr.azurecr.io/point-in-polygon-lookup-duckdb:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids:
+      - point-in-polygon-lookup-postgis-large
+
+  - id: point-in-polygon-lookup-postgis-large
+    image: doppaacr.azurecr.io/point-in-polygon-lookup-postgis:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids:
+      - point-in-polygon-lookup-duckdb-large
+
+  # ---- attribute-spatial-compound-filter ----
+  - id: attribute-spatial-compound-filter-duckdb-small
+    image: doppaacr.azurecr.io/attribute-spatial-compound-filter-duckdb:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: small
+    related_script_ids:
+      - attribute-spatial-compound-filter-postgis-small
+      - attribute-spatial-compound-filter-local-small
+
+  - id: attribute-spatial-compound-filter-postgis-small
+    image: doppaacr.azurecr.io/attribute-spatial-compound-filter-postgis:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: small
+    related_script_ids:
+      - attribute-spatial-compound-filter-duckdb-small
+      - attribute-spatial-compound-filter-local-small
+
+  - id: attribute-spatial-compound-filter-local-small
+    image: doppaacr.azurecr.io/attribute-spatial-compound-filter-local:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: small
+    related_script_ids:
+      - attribute-spatial-compound-filter-duckdb-small
+      - attribute-spatial-compound-filter-postgis-small
+
+  - id: attribute-spatial-compound-filter-duckdb-medium
+    image: doppaacr.azurecr.io/attribute-spatial-compound-filter-duckdb:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids:
+      - attribute-spatial-compound-filter-postgis-medium
+
+  - id: attribute-spatial-compound-filter-postgis-medium
+    image: doppaacr.azurecr.io/attribute-spatial-compound-filter-postgis:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids:
+      - attribute-spatial-compound-filter-duckdb-medium
+
+  - id: attribute-spatial-compound-filter-duckdb-large
+    image: doppaacr.azurecr.io/attribute-spatial-compound-filter-duckdb:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids:
+      - attribute-spatial-compound-filter-postgis-large
+
+  - id: attribute-spatial-compound-filter-postgis-large
+    image: doppaacr.azurecr.io/attribute-spatial-compound-filter-postgis:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids:
+      - attribute-spatial-compound-filter-duckdb-large
+
+  # ---- knn-search ----
+  - id: knn-search-duckdb-small
     image: doppaacr.azurecr.io/knn-search-duckdb:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
     related_script_ids:
-      [
-        "knn-search-local",
-        "knn-search-postgis",
-      ]
+      - knn-search-postgis-small
+      - knn-search-local-small
 
-  - id: knn-search-local
-    image: doppaacr.azurecr.io/knn-search-local:latest
-    cpu: 3
-    memory_gb: 8
-    dataset_size: small
-    related_script_ids:
-      [
-        "knn-search-duckdb",
-        "knn-search-postgis",
-      ]
-
-  - id: knn-search-postgis
+  - id: knn-search-postgis-small
     image: doppaacr.azurecr.io/knn-search-postgis:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
     related_script_ids:
-      [
-        "knn-search-duckdb",
-        "knn-search-local",
-      ]
+      - knn-search-duckdb-small
+      - knn-search-local-small
 
-  - id: national-scale-spatial-join-duckdb
+  - id: knn-search-local-small
+    image: doppaacr.azurecr.io/knn-search-local:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: small
+    related_script_ids:
+      - knn-search-duckdb-small
+      - knn-search-postgis-small
+
+  - id: knn-search-duckdb-medium
+    image: doppaacr.azurecr.io/knn-search-duckdb:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids:
+      - knn-search-postgis-medium
+
+  - id: knn-search-postgis-medium
+    image: doppaacr.azurecr.io/knn-search-postgis:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids:
+      - knn-search-duckdb-medium
+
+  - id: knn-search-duckdb-large
+    image: doppaacr.azurecr.io/knn-search-duckdb:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids:
+      - knn-search-postgis-large
+
+  - id: knn-search-postgis-large
+    image: doppaacr.azurecr.io/knn-search-postgis:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids:
+      - knn-search-duckdb-large
+
+  # ---- bbox-filtering ----
+  - id: bbox-filtering-duckdb-small
+    image: doppaacr.azurecr.io/bbox-filtering-duckdb:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: small
+    related_script_ids:
+      - bbox-filtering-postgis-small
+      - bbox-filtering-local-small
+
+  - id: bbox-filtering-postgis-small
+    image: doppaacr.azurecr.io/bbox-filtering-postgis:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: small
+    related_script_ids:
+      - bbox-filtering-duckdb-small
+      - bbox-filtering-local-small
+
+  - id: bbox-filtering-local-small
+    image: doppaacr.azurecr.io/bbox-filtering-local:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: small
+    related_script_ids:
+      - bbox-filtering-duckdb-small
+      - bbox-filtering-postgis-small
+
+  - id: bbox-filtering-duckdb-medium
+    image: doppaacr.azurecr.io/bbox-filtering-duckdb:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids:
+      - bbox-filtering-postgis-medium
+
+  - id: bbox-filtering-postgis-medium
+    image: doppaacr.azurecr.io/bbox-filtering-postgis:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids:
+      - bbox-filtering-duckdb-medium
+
+  - id: bbox-filtering-duckdb-large
+    image: doppaacr.azurecr.io/bbox-filtering-duckdb:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids:
+      - bbox-filtering-postgis-large
+
+  - id: bbox-filtering-postgis-large
+    image: doppaacr.azurecr.io/bbox-filtering-postgis:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids:
+      - bbox-filtering-duckdb-large
+
+  # ==================================================================
+  # RQ2 — National-scale spatial join (24 experiments)
+  # Single-node: DuckDB + PostGIS at small/medium/large (paired).
+  # Sedona: 2 strategies × 3 worker counts × 3 sizes, unpaired
+  # (each provisions its own cluster).
+  # ==================================================================
+
+  # ---- single-node ----
+  - id: national-scale-spatial-join-duckdb-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-duckdb:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
-    related_script_ids: ["national-scale-spatial-join-postgis"]
+    related_script_ids:
+      - national-scale-spatial-join-postgis-small
 
-  - id: national-scale-spatial-join-postgis
+  - id: national-scale-spatial-join-postgis-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-postgis:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
-    related_script_ids: ["national-scale-spatial-join-duckdb"]
+    related_script_ids:
+      - national-scale-spatial-join-duckdb-small
 
-  - id: national-scale-spatial-join-databricks-broadcast-2-nodes
+  - id: national-scale-spatial-join-duckdb-medium
+    image: doppaacr.azurecr.io/national-scale-spatial-join-duckdb:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids:
+      - national-scale-spatial-join-postgis-medium
+
+  - id: national-scale-spatial-join-postgis-medium
+    image: doppaacr.azurecr.io/national-scale-spatial-join-postgis:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids:
+      - national-scale-spatial-join-duckdb-medium
+
+  - id: national-scale-spatial-join-duckdb-large
+    image: doppaacr.azurecr.io/national-scale-spatial-join-duckdb:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids:
+      - national-scale-spatial-join-postgis-large
+
+  - id: national-scale-spatial-join-postgis-large
+    image: doppaacr.azurecr.io/national-scale-spatial-join-postgis:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids:
+      - national-scale-spatial-join-duckdb-large
+
+  # ---- Sedona broadcast strategy ----
+  - id: national-scale-spatial-join-databricks-broadcast-2-nodes-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-2-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
     related_script_ids: []
 
-  - id: national-scale-spatial-join-databricks-broadcast-4-nodes
+  - id: national-scale-spatial-join-databricks-broadcast-2-nodes-medium
+    image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-2-nodes:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids: []
+
+  - id: national-scale-spatial-join-databricks-broadcast-2-nodes-large
+    image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-2-nodes:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids: []
+
+  - id: national-scale-spatial-join-databricks-broadcast-4-nodes-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-4-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
     related_script_ids: []
 
-  - id: national-scale-spatial-join-databricks-broadcast-8-nodes
+  - id: national-scale-spatial-join-databricks-broadcast-4-nodes-medium
+    image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-4-nodes:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids: []
+
+  - id: national-scale-spatial-join-databricks-broadcast-4-nodes-large
+    image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-4-nodes:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids: []
+
+  - id: national-scale-spatial-join-databricks-broadcast-8-nodes-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-8-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
     related_script_ids: []
 
-  - id: national-scale-spatial-join-databricks-partitioned-2-nodes
+  - id: national-scale-spatial-join-databricks-broadcast-8-nodes-medium
+    image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-8-nodes:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids: []
+
+  - id: national-scale-spatial-join-databricks-broadcast-8-nodes-large
+    image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-8-nodes:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids: []
+
+  # ---- Sedona partitioned strategy ----
+  - id: national-scale-spatial-join-databricks-partitioned-2-nodes-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-2-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
     related_script_ids: []
 
-  - id: national-scale-spatial-join-databricks-partitioned-4-nodes
+  - id: national-scale-spatial-join-databricks-partitioned-2-nodes-medium
+    image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-2-nodes:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids: []
+
+  - id: national-scale-spatial-join-databricks-partitioned-2-nodes-large
+    image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-2-nodes:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids: []
+
+  - id: national-scale-spatial-join-databricks-partitioned-4-nodes-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-4-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
     related_script_ids: []
 
-  - id: national-scale-spatial-join-databricks-partitioned-8-nodes
+  - id: national-scale-spatial-join-databricks-partitioned-4-nodes-medium
+    image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-4-nodes:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids: []
+
+  - id: national-scale-spatial-join-databricks-partitioned-4-nodes-large
+    image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-4-nodes:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids: []
+
+  - id: national-scale-spatial-join-databricks-partitioned-8-nodes-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-8-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
     related_script_ids: []
 
+  - id: national-scale-spatial-join-databricks-partitioned-8-nodes-medium
+    image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-8-nodes:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: medium
+    related_script_ids: []
+
+  - id: national-scale-spatial-join-databricks-partitioned-8-nodes-large
+    image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-8-nodes:latest
+    cpu: 3
+    memory_gb: 8
+    dataset_size: large
+    related_script_ids: []
+
+# ====================================================================
+# Out-of-scope benchmarks (kept commented for easy re-enable).
+# Entrypoints remain in src/presentation/entrypoints/ and the dispatch
+# cases remain in benchmark_runner.py. To re-enable, uncomment here,
+# in docker-compose.yml, and in the two CI workflow matrices.
+# ====================================================================
+
+#  - id: db-scan-blob-storage
+#    image: doppaacr.azurecr.io/db-scan-blob-storage:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids: ["db-scan-postgis"]
+#
+#  - id: db-scan-postgis
+#    image: doppaacr.azurecr.io/db-scan-postgis:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids: ["db-scan-blob-storage"]
+#
+#  - id: vector-tiles-single-tile-pmtiles
+#    image: doppaacr.azurecr.io/vector-tiles-single-tile-pmtiles:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids: ["vector-tiles-single-tile-vmt"]
+#
+#  - id: vector-tiles-single-tile-vmt
+#    image: doppaacr.azurecr.io/vector-tiles-single-tile-vmt:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids: ["vector-tiles-single-tile-pmtiles"]
+#
 #  - id: vector-tiles-100k-pmtiles
 #    image: doppaacr.azurecr.io/vector-tiles-100k-pmtiles:latest
 #    cpu: 3
@@ -350,3 +479,113 @@ experiments:
 #    memory_gb: 8
 #    dataset_size: small
 #    related_script_ids: ["vector-tiles-100k-pmtiles"]
+#
+#  - id: spatial-aggregation-grid-duckdb
+#    image: doppaacr.azurecr.io/spatial-aggregation-grid-duckdb:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids: ["spatial-aggregation-grid-postgis"]
+#
+#  - id: spatial-aggregation-grid-postgis
+#    image: doppaacr.azurecr.io/spatial-aggregation-grid-postgis:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids: ["spatial-aggregation-grid-duckdb"]
+#
+#  - id: ordered-range-query-duckdb
+#    image: doppaacr.azurecr.io/ordered-range-query-duckdb:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids: ["ordered-range-query-postgis"]
+#
+#  - id: ordered-range-query-postgis
+#    image: doppaacr.azurecr.io/ordered-range-query-postgis:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids: ["ordered-range-query-duckdb"]
+#
+#  - id: bbox-filtering-simple-local
+#    image: doppaacr.azurecr.io/bbox-filtering-simple-local:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids: ["bbox-filtering-simple-blob-storage"]
+#
+#  - id: bbox-filtering-simple-blob-storage
+#    image: doppaacr.azurecr.io/bbox-filtering-simple-blob-storage:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids: ["bbox-filtering-simple-local"]
+#
+#  - id: bbox-filtering-advanced-duckdb
+#    image: doppaacr.azurecr.io/bbox-filtering-advanced-duckdb:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids: ["bbox-filtering-advanced-postgis"]
+#
+#  - id: bbox-filtering-advanced-postgis
+#    image: doppaacr.azurecr.io/bbox-filtering-advanced-postgis:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids: ["bbox-filtering-advanced-duckdb"]
+#
+#  - id: bbox-filtering-result-set-sizes-municipality-duckdb
+#    image: doppaacr.azurecr.io/bbox-filtering-result-set-sizes-municipality-duckdb:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids:
+#      - bbox-filtering-result-set-sizes-municipality-local
+#      - bbox-filtering-result-set-sizes-municipality-postgis
+#
+#  - id: bbox-filtering-result-set-sizes-municipality-postgis
+#    image: doppaacr.azurecr.io/bbox-filtering-result-set-sizes-municipality-postgis:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids:
+#      - bbox-filtering-result-set-sizes-municipality-local
+#      - bbox-filtering-result-set-sizes-municipality-duckdb
+#
+#  - id: bbox-filtering-result-set-sizes-municipality-local
+#    image: doppaacr.azurecr.io/bbox-filtering-result-set-sizes-municipality-local:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids:
+#      - bbox-filtering-result-set-sizes-municipality-duckdb
+#      - bbox-filtering-result-set-sizes-municipality-postgis
+#
+#  - id: bbox-filtering-result-set-sizes-county-duckdb
+#    image: doppaacr.azurecr.io/bbox-filtering-result-set-sizes-county-duckdb:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids:
+#      - bbox-filtering-result-set-sizes-county-local
+#      - bbox-filtering-result-set-sizes-county-postgis
+#
+#  - id: bbox-filtering-result-set-sizes-county-postgis
+#    image: doppaacr.azurecr.io/bbox-filtering-result-set-sizes-county-postgis:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids:
+#      - bbox-filtering-result-set-sizes-county-local
+#      - bbox-filtering-result-set-sizes-county-duckdb
+#
+#  - id: bbox-filtering-result-set-sizes-county-local
+#    image: doppaacr.azurecr.io/bbox-filtering-result-set-sizes-county-local:latest
+#    cpu: 3
+#    memory_gb: 8
+#    dataset_size: small
+#    related_script_ids:
+#      - bbox-filtering-result-set-sizes-county-duckdb
+#      - bbox-filtering-result-set-sizes-county-postgis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,230 +18,12 @@ services:
     image: container-orchestrator:latest
     command: python -m main
 
-  db-scan-blob-storage:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: db-scan-blob-storage:latest
-    command: python benchmark_runner.py --script-id db-scan-blob-storage --benchmark-run 1 --run-id ABCDEF
-
-  db-scan-postgis:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: db-scan-postgis:latest
-    command: python benchmark_runner.py --script-id db-scan-postgis --benchmark-run 1 --run-id ABCDEF
-
-  bbox-filtering-advanced-duckdb:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: bbox-filtering-advanced-duckdb:latest
-    command: python benchmark_runner.py --script-id bbox-filtering-advanced-duckdb --benchmark-run 1 --run-id ABCDEF
-
-  bbox-filtering-advanced-postgis:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: bbox-filtering-advanced-postgis:latest
-    command: python benchmark_runner.py --script-id bbox-filtering-advanced-postgis --benchmark-run 1 --run-id ABCDEF
-
-  bbox-filtering-simple-local:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: bbox-filtering-simple-local:latest
-    command: python benchmark_runner.py --script-id bbox-filtering-simple-local --benchmark-run 1 --run-id ABCDEF
-
-  bbox-filtering-simple-blob-storage:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: bbox-filtering-simple-blob-storage:latest
-    command: python benchmark_runner.py --script-id bbox-filtering-simple-blob-storage --benchmark-run 1 --run-id ABCDEF
-
-  vector-tiles-single-tile-pmtiles:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: vector-tiles-single-tile-pmtiles:latest
-    command: python benchmark_runner.py --script-id vector-tiles-single-tile-pmtiles --benchmark-run 1 --run-id ABCDEF
-
-  vector-tiles-single-tile-vmt:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: vector-tiles-single-tile-vmt:latest
-    command: python benchmark_runner.py --script-id vector-tiles-single-tile-vmt --benchmark-run 1 --run-id ABCDEF
-
-  vector-tiles-100k-pmtiles:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: vector-tiles-100k-pmtiles:latest
-    command: python benchmark_runner.py --script-id vector-tiles-100k-pmtiles --benchmark-run 1 --run-id ABCDEF
-
-  vector-tiles-100k-vmt:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: vector-tiles-100k-vmt:latest
-    command: python benchmark_runner.py --script-id vector-tiles-100k-vmt --benchmark-run 1 --run-id ABCDEF
-
-  bbox-filtering-result-set-sizes-neighborhood-duckdb:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: bbox-filtering-result-set-sizes-neighborhood-duckdb:latest
-    command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-neighborhood-duckdb --benchmark-run 1 --run-id ABCDEF
-
-  bbox-filtering-result-set-sizes-municipality-duckdb:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: bbox-filtering-result-set-sizes-municipality-duckdb:latest
-    command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-municipality-duckdb --benchmark-run 1 --run-id ABCDEF
-
-  bbox-filtering-result-set-sizes-county-duckdb:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: bbox-filtering-result-set-sizes-county-duckdb:latest
-    command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-county-duckdb --benchmark-run 1 --run-id ABCDEF
-
-  bbox-filtering-result-set-sizes-neighborhood-postgis:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: bbox-filtering-result-set-sizes-neighborhood-postgis:latest
-    command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-neighborhood-postgis --benchmark-run 1 --run-id ABCDEF
-
-  bbox-filtering-result-set-sizes-municipality-postgis:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: bbox-filtering-result-set-sizes-municipality-postgis:latest
-    command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-municipality-postgis --benchmark-run 1 --run-id ABCDEF
-
-  bbox-filtering-result-set-sizes-county-postgis:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: bbox-filtering-result-set-sizes-county-postgis:latest
-    command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-county-postgis --benchmark-run 1 --run-id ABCDEF
-
-  bbox-filtering-result-set-sizes-neighborhood-local:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: bbox-filtering-result-set-sizes-neighborhood-local:latest
-    command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-neighborhood-local --benchmark-run 1 --run-id ABCDEF
-
-  bbox-filtering-result-set-sizes-municipality-local:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: bbox-filtering-result-set-sizes-municipality-local:latest
-    command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-municipality-local --benchmark-run 1 --run-id ABCDEF
-
-  bbox-filtering-result-set-sizes-county-local:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: bbox-filtering-result-set-sizes-county-local:latest
-    command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-county-local --benchmark-run 1 --run-id ABCDEF
-
-  spatial-aggregation-grid-duckdb:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: spatial-aggregation-grid-duckdb:latest
-    command: python benchmark_runner.py --script-id spatial-aggregation-grid-duckdb --benchmark-run 1 --run-id ABCDEF
-
-  spatial-aggregation-grid-postgis:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: spatial-aggregation-grid-postgis:latest
-    command: python benchmark_runner.py --script-id spatial-aggregation-grid-postgis --benchmark-run 1 --run-id ABCDEF
-
-  attribute-spatial-compound-filter-duckdb:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: attribute-spatial-compound-filter-duckdb:latest
-    command: python benchmark_runner.py --script-id attribute-spatial-compound-filter-duckdb --benchmark-run 1 --run-id ABCDEF
-
-  attribute-spatial-compound-filter-postgis:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: attribute-spatial-compound-filter-postgis:latest
-    command: python benchmark_runner.py --script-id attribute-spatial-compound-filter-postgis --benchmark-run 1 --run-id ABCDEF
-
-  ordered-range-query-duckdb:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: ordered-range-query-duckdb:latest
-    command: python benchmark_runner.py --script-id ordered-range-query-duckdb --benchmark-run 1 --run-id ABCDEF
-
-  ordered-range-query-postgis:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: ordered-range-query-postgis:latest
-    command: python benchmark_runner.py --script-id ordered-range-query-postgis --benchmark-run 1 --run-id ABCDEF
+  # =================================================================
+  # RQ1 — Single-machine query benchmarks
+  # One service per (query_type, engine). Dataset size is a runtime
+  # arg passed by main.py per experiment; the same image serves all
+  # size tiers.
+  # =================================================================
 
   point-in-polygon-lookup-duckdb:
     env_file:
@@ -261,6 +43,100 @@ services:
     image: point-in-polygon-lookup-postgis:latest
     command: python benchmark_runner.py --script-id point-in-polygon-lookup-postgis --benchmark-run 1 --run-id ABCDEF
 
+  point-in-polygon-lookup-local:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: point-in-polygon-lookup-local:latest
+    command: python benchmark_runner.py --script-id point-in-polygon-lookup-local --benchmark-run 1 --run-id ABCDEF
+
+  attribute-spatial-compound-filter-duckdb:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: attribute-spatial-compound-filter-duckdb:latest
+    command: python benchmark_runner.py --script-id attribute-spatial-compound-filter-duckdb --benchmark-run 1 --run-id ABCDEF
+
+  attribute-spatial-compound-filter-postgis:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: attribute-spatial-compound-filter-postgis:latest
+    command: python benchmark_runner.py --script-id attribute-spatial-compound-filter-postgis --benchmark-run 1 --run-id ABCDEF
+
+  attribute-spatial-compound-filter-local:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: attribute-spatial-compound-filter-local:latest
+    command: python benchmark_runner.py --script-id attribute-spatial-compound-filter-local --benchmark-run 1 --run-id ABCDEF
+
+  knn-search-duckdb:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: knn-search-duckdb:latest
+    command: python benchmark_runner.py --script-id knn-search-duckdb --benchmark-run 1 --run-id ABCDEF
+
+  knn-search-postgis:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: knn-search-postgis:latest
+    command: python benchmark_runner.py --script-id knn-search-postgis --benchmark-run 1 --run-id ABCDEF
+
+  knn-search-local:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: knn-search-local:latest
+    command: python benchmark_runner.py --script-id knn-search-local --benchmark-run 1 --run-id ABCDEF
+
+  bbox-filtering-duckdb:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: bbox-filtering-duckdb:latest
+    command: python benchmark_runner.py --script-id bbox-filtering-duckdb --benchmark-run 1 --run-id ABCDEF
+
+  bbox-filtering-postgis:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: bbox-filtering-postgis:latest
+    command: python benchmark_runner.py --script-id bbox-filtering-postgis --benchmark-run 1 --run-id ABCDEF
+
+  bbox-filtering-local:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: bbox-filtering-local:latest
+    command: python benchmark_runner.py --script-id bbox-filtering-local --benchmark-run 1 --run-id ABCDEF
+
+  # =================================================================
+  # RQ2 — National-scale spatial join
+  # =================================================================
+
   national-scale-spatial-join-duckdb:
     env_file:
       - .env
@@ -279,32 +155,59 @@ services:
     image: national-scale-spatial-join-postgis:latest
     command: python benchmark_runner.py --script-id national-scale-spatial-join-postgis --benchmark-run 1 --run-id ABCDEF
 
-  national-scale-spatial-join-databricks-2-nodes:
+  national-scale-spatial-join-databricks-broadcast-2-nodes:
     env_file:
       - .env
     build:
       context: .
       dockerfile: .docker/Query.Dockerfile
-    image: national-scale-spatial-join-databricks-2-nodes:latest
-    command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-2-nodes --benchmark-run 1 --run-id ABCDEF
+    image: national-scale-spatial-join-databricks-broadcast-2-nodes:latest
+    command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-broadcast-2-nodes --benchmark-run 1 --run-id ABCDEF
 
-  national-scale-spatial-join-databricks-4-nodes:
+  national-scale-spatial-join-databricks-broadcast-4-nodes:
     env_file:
       - .env
     build:
       context: .
       dockerfile: .docker/Query.Dockerfile
-    image: national-scale-spatial-join-databricks-4-nodes:latest
-    command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-4-nodes --benchmark-run 1 --run-id ABCDEF
+    image: national-scale-spatial-join-databricks-broadcast-4-nodes:latest
+    command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-broadcast-4-nodes --benchmark-run 1 --run-id ABCDEF
 
-  national-scale-spatial-join-databricks-8-nodes:
+  national-scale-spatial-join-databricks-broadcast-8-nodes:
     env_file:
       - .env
     build:
       context: .
       dockerfile: .docker/Query.Dockerfile
-    image: national-scale-spatial-join-databricks-8-nodes:latest
-    command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-8-nodes --benchmark-run 1 --run-id ABCDEF
+    image: national-scale-spatial-join-databricks-broadcast-8-nodes:latest
+    command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-broadcast-8-nodes --benchmark-run 1 --run-id ABCDEF
+
+  national-scale-spatial-join-databricks-partitioned-2-nodes:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: national-scale-spatial-join-databricks-partitioned-2-nodes:latest
+    command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-partitioned-2-nodes --benchmark-run 1 --run-id ABCDEF
+
+  national-scale-spatial-join-databricks-partitioned-4-nodes:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: national-scale-spatial-join-databricks-partitioned-4-nodes:latest
+    command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-partitioned-4-nodes --benchmark-run 1 --run-id ABCDEF
+
+  national-scale-spatial-join-databricks-partitioned-8-nodes:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: .docker/Query.Dockerfile
+    image: national-scale-spatial-join-databricks-partitioned-8-nodes:latest
+    command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-partitioned-8-nodes --benchmark-run 1 --run-id ABCDEF
 
   vmt-api-server:
     env_file:
@@ -316,3 +219,242 @@ services:
       - "8000:8000"
     image: vmt-api-server:latest
     command: uvicorn src.presentation.endpoints.tile_server:app --host 0.0.0.0 --port 8000
+
+  # =================================================================
+  # Out-of-scope services (kept commented for easy re-enable).
+  # Mirrors the commented-out section at the bottom of benchmarks.yml.
+  # =================================================================
+
+  # db-scan-blob-storage:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: db-scan-blob-storage:latest
+  #   command: python benchmark_runner.py --script-id db-scan-blob-storage --benchmark-run 1 --run-id ABCDEF
+
+  # db-scan-postgis:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: db-scan-postgis:latest
+  #   command: python benchmark_runner.py --script-id db-scan-postgis --benchmark-run 1 --run-id ABCDEF
+
+  # bbox-filtering-simple-local:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: bbox-filtering-simple-local:latest
+  #   command: python benchmark_runner.py --script-id bbox-filtering-simple-local --benchmark-run 1 --run-id ABCDEF
+
+  # bbox-filtering-simple-blob-storage:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: bbox-filtering-simple-blob-storage:latest
+  #   command: python benchmark_runner.py --script-id bbox-filtering-simple-blob-storage --benchmark-run 1 --run-id ABCDEF
+
+  # bbox-filtering-advanced-duckdb:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: bbox-filtering-advanced-duckdb:latest
+  #   command: python benchmark_runner.py --script-id bbox-filtering-advanced-duckdb --benchmark-run 1 --run-id ABCDEF
+
+  # bbox-filtering-advanced-postgis:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: bbox-filtering-advanced-postgis:latest
+  #   command: python benchmark_runner.py --script-id bbox-filtering-advanced-postgis --benchmark-run 1 --run-id ABCDEF
+
+  # vector-tiles-single-tile-pmtiles:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: vector-tiles-single-tile-pmtiles:latest
+  #   command: python benchmark_runner.py --script-id vector-tiles-single-tile-pmtiles --benchmark-run 1 --run-id ABCDEF
+
+  # vector-tiles-single-tile-vmt:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: vector-tiles-single-tile-vmt:latest
+  #   command: python benchmark_runner.py --script-id vector-tiles-single-tile-vmt --benchmark-run 1 --run-id ABCDEF
+
+  # vector-tiles-100k-pmtiles:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: vector-tiles-100k-pmtiles:latest
+  #   command: python benchmark_runner.py --script-id vector-tiles-100k-pmtiles --benchmark-run 1 --run-id ABCDEF
+
+  # vector-tiles-100k-vmt:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: vector-tiles-100k-vmt:latest
+  #   command: python benchmark_runner.py --script-id vector-tiles-100k-vmt --benchmark-run 1 --run-id ABCDEF
+
+  # spatial-aggregation-grid-duckdb:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: spatial-aggregation-grid-duckdb:latest
+  #   command: python benchmark_runner.py --script-id spatial-aggregation-grid-duckdb --benchmark-run 1 --run-id ABCDEF
+
+  # spatial-aggregation-grid-postgis:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: spatial-aggregation-grid-postgis:latest
+  #   command: python benchmark_runner.py --script-id spatial-aggregation-grid-postgis --benchmark-run 1 --run-id ABCDEF
+
+  # ordered-range-query-duckdb:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: ordered-range-query-duckdb:latest
+  #   command: python benchmark_runner.py --script-id ordered-range-query-duckdb --benchmark-run 1 --run-id ABCDEF
+
+  # ordered-range-query-postgis:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: ordered-range-query-postgis:latest
+  #   command: python benchmark_runner.py --script-id ordered-range-query-postgis --benchmark-run 1 --run-id ABCDEF
+
+  # bbox-filtering-result-set-sizes-neighborhood-duckdb:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: bbox-filtering-result-set-sizes-neighborhood-duckdb:latest
+  #   command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-neighborhood-duckdb --benchmark-run 1 --run-id ABCDEF
+
+  # bbox-filtering-result-set-sizes-municipality-duckdb:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: bbox-filtering-result-set-sizes-municipality-duckdb:latest
+  #   command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-municipality-duckdb --benchmark-run 1 --run-id ABCDEF
+
+  # bbox-filtering-result-set-sizes-county-duckdb:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: bbox-filtering-result-set-sizes-county-duckdb:latest
+  #   command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-county-duckdb --benchmark-run 1 --run-id ABCDEF
+
+  # bbox-filtering-result-set-sizes-neighborhood-postgis:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: bbox-filtering-result-set-sizes-neighborhood-postgis:latest
+  #   command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-neighborhood-postgis --benchmark-run 1 --run-id ABCDEF
+
+  # bbox-filtering-result-set-sizes-municipality-postgis:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: bbox-filtering-result-set-sizes-municipality-postgis:latest
+  #   command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-municipality-postgis --benchmark-run 1 --run-id ABCDEF
+
+  # bbox-filtering-result-set-sizes-county-postgis:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: bbox-filtering-result-set-sizes-county-postgis:latest
+  #   command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-county-postgis --benchmark-run 1 --run-id ABCDEF
+
+  # bbox-filtering-result-set-sizes-neighborhood-local:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: bbox-filtering-result-set-sizes-neighborhood-local:latest
+  #   command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-neighborhood-local --benchmark-run 1 --run-id ABCDEF
+
+  # bbox-filtering-result-set-sizes-municipality-local:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: bbox-filtering-result-set-sizes-municipality-local:latest
+  #   command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-municipality-local --benchmark-run 1 --run-id ABCDEF
+
+  # bbox-filtering-result-set-sizes-county-local:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: bbox-filtering-result-set-sizes-county-local:latest
+  #   command: python benchmark_runner.py --script-id bbox-filtering-result-set-sizes-county-local --benchmark-run 1 --run-id ABCDEF
+
+  # national-scale-spatial-join-databricks-2-nodes:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: national-scale-spatial-join-databricks-2-nodes:latest
+  #   command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-2-nodes --benchmark-run 1 --run-id ABCDEF
+
+  # national-scale-spatial-join-databricks-4-nodes:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: national-scale-spatial-join-databricks-4-nodes:latest
+  #   command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-4-nodes --benchmark-run 1 --run-id ABCDEF
+
+  # national-scale-spatial-join-databricks-8-nodes:
+  #   env_file:
+  #     - .env
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Query.Dockerfile
+  #   image: national-scale-spatial-join-databricks-8-nodes:latest
+  #   command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-8-nodes --benchmark-run 1 --run-id ABCDEF


### PR DESCRIPTION
Rewrites benchmarks.yml to the 52 active experiments from Table 4.2.1 (RQ1: 4 query types x 7 size variants = 28; RQ2: 6 single-node + 18 Sedona = 24). RQ1 pairs three engines at small and two at medium/large via `related_script_ids`; Sedona variants run unpaired.

Adds `_strip_dataset_size_suffix` in benchmark_runner.py so 52 unique yml ids (each carrying a -small/-medium/-large tail) dispatch to the shared base entrypoint while dataset_size flows in via --dataset-size.

Collapses docker-compose.yml to 20 active services (one per (query_type, engine) pair) and trims both CI build matrices to match. Out-of-scope benchmarks stay in tree but are commented out at the bottom of benchmarks.yml, docker-compose.yml, and the workflow matrices so re-enabling them is a single search-and-uncomment.

Adds a Test matrix table to the README documenting which experiments launch as a parallel pair group and which run alone.