### PR TITLE
#281 Updated container naming rules

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
-﻿import json
+﻿import hashlib
+import json
 import os
 import random
 import shutil
@@ -103,7 +104,7 @@ def _run_container_benchmark(
     memory_gb = str(experiment["memory_gb"])
     dataset_size = str(experiment.get("dataset_size", "small"))
 
-    container_group_name = f"benchmark-{experiment_id}"
+    container_group_name = _container_group_name(experiment_id)
     _delete_container_instance(container_group_name=container_group_name)
     _create_container_instance(
         run_id=run_id,
@@ -126,6 +127,17 @@ def _create_run_id() -> str:
     )
 
     return f"{date_prefix}-{suffix}"
+
+
+def _container_group_name(experiment_id: str) -> str:
+    name = f"benchmark-{experiment_id}"
+    if len(name) <= 63:
+        return name
+
+    digest = hashlib.sha1(experiment_id.encode()).hexdigest()[:8]
+    budget = 63 - len("benchmark-") - 1 - len(digest)
+    truncated = experiment_id[:budget].rstrip("-")
+    return f"benchmark-{truncated}-{digest}"
 
 
 # noinspection PyDeprecation
@@ -384,7 +396,7 @@ def _clear_all_container_instances(
 ) -> None:
     experiment_ids = [exp["id"] for exp in experiments]
     for experiment_id in experiment_ids:
-        _delete_container_instance(f"benchmark-{experiment_id}")
+        _delete_container_instance(_container_group_name(str(experiment_id)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request improves how container group names are generated and handled, especially to ensure they do not exceed Azure's 63-character limit. The main changes introduce a helper function to generate compliant container group names, update all relevant usages, and add a hashing mechanism for long names.

**Container group name handling:**

* Added a new `_container_group_name` function in `main.py` that generates container group names compliant with Azure's 63-character limit, using a truncated experiment ID and an 8-character SHA-1 hash suffix if needed.
* Updated all usages of container group name construction to use the new `_container_group_name` function, including in `_run_container_benchmark` and `_clear_all_container_instances`. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L106-R107) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L387-R399)

**Dependency updates:**

* Added `import hashlib` to support the new hashing logic for container group names.