### PR TITLE
Feature/286 batch queries for run time optimization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Python, DuckDB (spatial), PostGIS on Azure Database for PostgreSQL, Apache Sedon
 - Dependency direction: `presentation` → `application` → `domain`; `infra` implements `application/contracts`. No upward imports across layers.
 - Env vars and tunable constants belong in `src/config.py` (`Config`). Do not call `os.getenv` from services or entrypoints. *Why: one place to audit secrets and tweak benchmark sizes.*
 - Secrets live in `.env` (gitignored) and are forwarded to ACI as `--secure-environment-variables` from `main.py`.
-- Benchmark pairing: related benchmarks list each other bidirectionally in `related_script_ids` (e.g. `*-duckdb` ↔ `*-postgis`). The orchestrator dedupes via `completed_experiments`, so each pair runs once as a single parallel batch. *Why: peers execute under the same wall-clock window for fair comparison.*
+- Benchmark batching: members of a batch list each other bidirectionally in `related_script_ids`. The orchestrator dedupes via `completed_experiments`, so each batch runs once as one parallel `ThreadPoolExecutor` fan-out. A batch must satisfy four constraints simultaneously: (a) same query type, (b) same `dataset_size`, (c) at most one PostGIS member (shared Azure Postgres server), (d) Databricks cluster vCPU sum ≤ 80, computed as `(workers + 1) × 4` per Sedona member on `Standard_D4s_v3`. See `README.md#pairing-and-randomization` for the full batch listing. *Why: peers must execute under the same wall-clock window for fair comparison, without contending on shared infrastructure or breaching regional quota.*
 - Adding a benchmark requires three edits in lockstep: file in `src/presentation/entrypoints/`, `case` arm in `benchmark_runner.py`, and an entry in `benchmarks.yml`. Missing any one silently breaks dispatch or orchestration.
 
 ## Commands
@@ -38,7 +38,7 @@ python benchmark_runner.py --script-id <id> --benchmark-run 1 --run-id dev  # on
 <important if="you are adding a new benchmark">
 - Create `src/presentation/entrypoints/<name>.py`; re-export from `entrypoints/__init__.py`.
 - Add `case "<script-id>":` in `benchmark_runner.py`.
-- Append entry to `benchmarks.yml` with `id`, `image`, `cpu`, `memory_gb`, `related_script_ids` (list peers both ways).
+- Append entry to `benchmarks.yml` with `id`, `image`, `cpu`, `memory_gb`, `dataset_size`, `related_script_ids` (list peers both ways; assign to an existing batch that satisfies the four constraints in the batching invariant, or create a new batch).
 - If a new service is needed: contract in `application/contracts/`, impl in `infra/infrastructure/services/`, provider in `containers.py`.
 </important>
 

--- a/README.md
+++ b/README.md
@@ -152,24 +152,40 @@ be decomposed into read, shuffle, and driver collection time.
 ### Pairing and randomization
 
 `main.py` shuffles the experiment list with `random.Random(benchmark_run)` before launching containers. Experiments
-that compare directly (for example `point-in-polygon-lookup-duckdb-small` and `point-in-polygon-lookup-postgis-small`)
-declare each other under `related_script_ids` in `benchmarks.yml` and are launched concurrently via a
-`ThreadPoolExecutor`. Running a paired benchmark in the same wall-clock window controls for short-term cloud
-variability between the engines being compared.
+that should share a wall-clock window declare each other under `related_script_ids` in `benchmarks.yml` and are
+launched concurrently via a `ThreadPoolExecutor`. Running paired benchmarks in the same window controls for
+short-term cloud variability between the engines being compared.
 
 Concretely, the outer orchestrator loop is serial: it picks the next experiment that has not yet completed, fans out
-its pair group as one parallel batch, waits for the whole batch to finish, marks every member completed, and moves on.
-At any moment one pair group is in flight; within that group every member runs on its own ACI in parallel.
+its peer batch in parallel, waits for the whole batch to finish, marks every member completed, and moves on. At any
+moment one batch is in flight; within that batch every member runs on its own ACI in parallel.
+
+The 52 experiments are packed into 20 batches under four constraints that the `related_script_ids` graph encodes:
+
+1. **Same query type** per batch — `point-in-polygon-lookup`, `knn-search`, `bbox-filtering`, or
+   `national-scale-spatial-join` never mix.
+2. **Same dataset size** per batch — `small`, `medium`, and `large` never overlap, so storage cache state and
+   regional VM pressure are comparable across batch members.
+3. **At most one PostGIS experiment** per batch — Azure Database for PostgreSQL is a single shared instance and two
+   concurrent PostGIS queries would contend on shared buffers, OS page cache, and CPU.
+4. **At most 80 Databricks cluster vCPU** per batch — `Standard_D4s_v3` is 4 vCPU per node, each Sedona cluster
+   uses `(workers + 1) × 4` vCPU (driver + workers), and the Databricks workspace's regional quota for that VM
+   family is 80. DuckDB, Shapefile, and PostGIS draw from a separate ACI quota and do not count.
+
+DuckDB and Shapefile experiments are process-local inside their own ACI, so multiple of either may run concurrently
+without disturbing each other. Each Sedona variant provisions its own Databricks cluster on disjoint VMs, so two
+Sedona experiments in the same batch do not share any runtime state beyond the regional vCPU pool already capped
+by constraint 4.
 
 ### Test matrix
 
-The matrix below is the active set of 52 experiments grouped into 40 parallel pair groups. Each cell lists the
-engines that launch together in the same wall-clock window; size suffixes (`-small`, `-medium`, `-large`) are
-appended to the experiment ids in `benchmarks.yml` and forwarded to each container as `--dataset-size`. Shapefile
-(`local`) only participates at the `small` tier per the thesis methodology — it represents the laptop-workflow
-reference, not a scalable engine.
+The matrix below is the active set of 52 experiments grouped into 20 parallel batches. Each cell lists the engines
+or Sedona configurations that launch together in the same wall-clock window; size suffixes (`-small`, `-medium`,
+`-large`) are appended to the experiment ids in `benchmarks.yml` and forwarded to each container as `--dataset-size`.
+Shapefile (`local`) only participates at the `small` tier per the thesis methodology — it represents the
+laptop-workflow reference, not a scalable engine.
 
-**RQ1 — Single-machine query benchmarks** (15 experiments, 6 pair groups)
+**RQ1 — Single-machine query benchmarks** (15 experiments, 6 batches)
 
 | Query type                | `small` (3-way)          | `large` (2-way)  |
 |---------------------------|--------------------------|------------------|
@@ -180,25 +196,51 @@ reference, not a scalable engine.
 The medium tier was dropped from the surviving RQ1 queries and `attribute-spatial-compound-filter` was removed
 across the board (issue #281); the 13 freed cells are reinvested in RQ2.
 
-**RQ2 — National-scale spatial join** (37 experiments, 34 pair groups)
+**RQ2 — National-scale spatial join** (37 experiments, 14 batches)
 
-| Engine / strategy                | `small`               | `medium`              | `large`                              |
-|----------------------------------|-----------------------|-----------------------|--------------------------------------|
-| Single-node (paired)             | duckdb · postgis      | duckdb · postgis      | duckdb · postgis                     |
-| Sedona `broadcast` (unpaired)    | 4 / 8 nodes           | 2 / 4 / 8 nodes       | 2 / 4 / 8 / 12 / 16 nodes            |
-| Sedona `partitioned` (unpaired)  | 4 / 8 nodes           | 2 / 4 / 8 nodes       | 2 / 4 / 8 / 12 / 16 nodes            |
-| Sedona `default` (unpaired)      | 2 / 4 / 8 nodes       | 2 / 4 / 8 nodes       | 2 / 4 / 8 / 12 / 16 nodes            |
+| Engine / strategy   | `small`             | `medium`            | `large`                   |
+|---------------------|---------------------|---------------------|---------------------------|
+| Single-node         | duckdb · postgis    | duckdb · postgis    | duckdb · postgis          |
+| Sedona `broadcast`  | 4 / 8 nodes         | 2 / 4 / 8 nodes     | 2 / 4 / 8 / 12 / 16 nodes |
+| Sedona `partitioned`| 4 / 8 nodes         | 2 / 4 / 8 nodes     | 2 / 4 / 8 / 12 / 16 nodes |
+| Sedona `default`    | 2 / 4 / 8 nodes     | 2 / 4 / 8 nodes     | 2 / 4 / 8 / 12 / 16 nodes |
 
-Cells in the **paired** rows list every engine that launches in the same wall-clock window (one ACI each, started
-concurrently via `ThreadPoolExecutor`). Cells in the **unpaired** rows list separate experiments that each run alone
-in their own pair group — they share a row only because they share a strategy/size, not because they co-launch.
-Sedona variants are unpaired because each provisions its own Databricks cluster.
+Within each size column, single-node and Sedona experiments are packed into the same batches up to the 80 vCPU
+Databricks budget — the table groups by strategy for readability, not by batch membership. Concrete batch
+membership is whatever `related_script_ids` in `benchmarks.yml` declares; see the batch listing below.
 
 The 2-node row is omitted at `small` for `broadcast` and `partitioned`: at ~5M polygons those configurations were
 weakly differentiated from `default`; the freed cells fund the 12-/16-node extension of the scaling curve at `large`.
 The `default` strategy applies no `broadcast()` hint and no Sedona partitioner configuration; Spark's cost-based
 optimizer picks the plan, so it serves as the apples-to-apples baseline against which `broadcast` and `partitioned`
 are compared.
+
+**Batch listing.** Twenty batches in total. The Databricks vCPU column sums `(workers + 1) × 4` over Sedona members
+of the batch; single-node and DuckDB/Shapefile ACIs draw from a separate quota. Sequential execution order follows
+the seeded shuffle.
+
+| Batch | Type                        | Size   | Databricks vCPU | Members |
+|-------|-----------------------------|--------|-----------------|---------|
+| P1    | point-in-polygon-lookup     | small  | 0               | duckdb · postgis · local |
+| P2    | point-in-polygon-lookup     | large  | 0               | duckdb · postgis |
+| K1    | knn-search                  | small  | 0               | duckdb · postgis · local |
+| K2    | knn-search                  | large  | 0               | duckdb · postgis |
+| B1    | bbox-filtering              | small  | 0               | duckdb · postgis · local |
+| B2    | bbox-filtering              | large  | 0               | duckdb · postgis |
+| A_S1  | national-scale-spatial-join | small  | 72              | broadcast-8 · partitioned-8 · duckdb · postgis |
+| A_S2  | national-scale-spatial-join | small  | 76              | default-8 · broadcast-4 · partitioned-4 |
+| A_S3  | national-scale-spatial-join | small  | 32              | default-4 · default-2 |
+| A_M1  | national-scale-spatial-join | medium | 72              | broadcast-8 · partitioned-8 · duckdb · postgis |
+| A_M2  | national-scale-spatial-join | medium | 76              | default-8 · broadcast-4 · partitioned-4 |
+| A_M3  | national-scale-spatial-join | medium | 56              | default-4 · broadcast-2 · partitioned-2 · default-2 |
+| A_L1  | national-scale-spatial-join | large  | 80              | broadcast-16 · broadcast-2 |
+| A_L2  | national-scale-spatial-join | large  | 80              | partitioned-16 · partitioned-2 |
+| A_L3  | national-scale-spatial-join | large  | 80              | default-16 · default-2 |
+| A_L4  | national-scale-spatial-join | large  | 72              | broadcast-12 · broadcast-4 |
+| A_L5  | national-scale-spatial-join | large  | 72              | partitioned-12 · partitioned-4 |
+| A_L6  | national-scale-spatial-join | large  | 72              | default-12 · default-4 |
+| A_L7  | national-scale-spatial-join | large  | 72              | broadcast-8 · partitioned-8 |
+| A_L8  | national-scale-spatial-join | large  | 36              | default-8 · duckdb · postgis |
 
 ## Dataset layout
 

--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -161,6 +161,8 @@ experiments:
     memory_gb: 8
     dataset_size: small
     related_script_ids:
+      - national-scale-spatial-join-databricks-broadcast-8-nodes-small
+      - national-scale-spatial-join-databricks-partitioned-8-nodes-small
       - national-scale-spatial-join-postgis-small
 
   - id: national-scale-spatial-join-postgis-small
@@ -169,6 +171,8 @@ experiments:
     memory_gb: 8
     dataset_size: small
     related_script_ids:
+      - national-scale-spatial-join-databricks-broadcast-8-nodes-small
+      - national-scale-spatial-join-databricks-partitioned-8-nodes-small
       - national-scale-spatial-join-duckdb-small
 
   - id: national-scale-spatial-join-duckdb-medium
@@ -177,6 +181,8 @@ experiments:
     memory_gb: 8
     dataset_size: medium
     related_script_ids:
+      - national-scale-spatial-join-databricks-broadcast-8-nodes-medium
+      - national-scale-spatial-join-databricks-partitioned-8-nodes-medium
       - national-scale-spatial-join-postgis-medium
 
   - id: national-scale-spatial-join-postgis-medium
@@ -185,6 +191,8 @@ experiments:
     memory_gb: 8
     dataset_size: medium
     related_script_ids:
+      - national-scale-spatial-join-databricks-broadcast-8-nodes-medium
+      - national-scale-spatial-join-databricks-partitioned-8-nodes-medium
       - national-scale-spatial-join-duckdb-medium
 
   - id: national-scale-spatial-join-duckdb-large
@@ -193,6 +201,7 @@ experiments:
     memory_gb: 8
     dataset_size: large
     related_script_ids:
+      - national-scale-spatial-join-databricks-default-8-nodes-large
       - national-scale-spatial-join-postgis-large
 
   - id: national-scale-spatial-join-postgis-large
@@ -201,6 +210,7 @@ experiments:
     memory_gb: 8
     dataset_size: large
     related_script_ids:
+      - national-scale-spatial-join-databricks-default-8-nodes-large
       - national-scale-spatial-join-duckdb-large
 
   # ---- Sedona broadcast strategy ----
@@ -209,70 +219,88 @@ experiments:
     cpu: 3
     memory_gb: 8
     dataset_size: medium
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-default-4-nodes-medium
+      - national-scale-spatial-join-databricks-partitioned-2-nodes-medium
+      - national-scale-spatial-join-databricks-default-2-nodes-medium
 
   - id: national-scale-spatial-join-databricks-broadcast-2-nodes-large
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-2-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: large
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-broadcast-16-nodes-large
 
   - id: national-scale-spatial-join-databricks-broadcast-4-nodes-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-4-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-default-8-nodes-small
+      - national-scale-spatial-join-databricks-partitioned-4-nodes-small
 
   - id: national-scale-spatial-join-databricks-broadcast-4-nodes-medium
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-4-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: medium
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-default-8-nodes-medium
+      - national-scale-spatial-join-databricks-partitioned-4-nodes-medium
 
   - id: national-scale-spatial-join-databricks-broadcast-4-nodes-large
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-4-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: large
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-broadcast-12-nodes-large
 
   - id: national-scale-spatial-join-databricks-broadcast-8-nodes-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-8-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-partitioned-8-nodes-small
+      - national-scale-spatial-join-duckdb-small
+      - national-scale-spatial-join-postgis-small
 
   - id: national-scale-spatial-join-databricks-broadcast-8-nodes-medium
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-8-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: medium
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-partitioned-8-nodes-medium
+      - national-scale-spatial-join-duckdb-medium
+      - national-scale-spatial-join-postgis-medium
 
   - id: national-scale-spatial-join-databricks-broadcast-8-nodes-large
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-8-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: large
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-partitioned-8-nodes-large
 
   - id: national-scale-spatial-join-databricks-broadcast-12-nodes-large
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-12-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: large
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-broadcast-4-nodes-large
 
   - id: national-scale-spatial-join-databricks-broadcast-16-nodes-large
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-16-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: large
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-broadcast-2-nodes-large
 
   # ---- Sedona partitioned strategy ----
   - id: national-scale-spatial-join-databricks-partitioned-2-nodes-medium
@@ -280,70 +308,88 @@ experiments:
     cpu: 3
     memory_gb: 8
     dataset_size: medium
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-default-4-nodes-medium
+      - national-scale-spatial-join-databricks-broadcast-2-nodes-medium
+      - national-scale-spatial-join-databricks-default-2-nodes-medium
 
   - id: national-scale-spatial-join-databricks-partitioned-2-nodes-large
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-2-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: large
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-partitioned-16-nodes-large
 
   - id: national-scale-spatial-join-databricks-partitioned-4-nodes-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-4-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-default-8-nodes-small
+      - national-scale-spatial-join-databricks-broadcast-4-nodes-small
 
   - id: national-scale-spatial-join-databricks-partitioned-4-nodes-medium
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-4-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: medium
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-default-8-nodes-medium
+      - national-scale-spatial-join-databricks-broadcast-4-nodes-medium
 
   - id: national-scale-spatial-join-databricks-partitioned-4-nodes-large
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-4-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: large
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-partitioned-12-nodes-large
 
   - id: national-scale-spatial-join-databricks-partitioned-8-nodes-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-8-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-broadcast-8-nodes-small
+      - national-scale-spatial-join-duckdb-small
+      - national-scale-spatial-join-postgis-small
 
   - id: national-scale-spatial-join-databricks-partitioned-8-nodes-medium
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-8-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: medium
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-broadcast-8-nodes-medium
+      - national-scale-spatial-join-duckdb-medium
+      - national-scale-spatial-join-postgis-medium
 
   - id: national-scale-spatial-join-databricks-partitioned-8-nodes-large
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-8-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: large
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-broadcast-8-nodes-large
 
   - id: national-scale-spatial-join-databricks-partitioned-12-nodes-large
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-12-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: large
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-partitioned-4-nodes-large
 
   - id: national-scale-spatial-join-databricks-partitioned-16-nodes-large
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-16-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: large
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-partitioned-2-nodes-large
 
   # ---- Sedona default strategy (apples-to-apples baseline) ----
   - id: national-scale-spatial-join-databricks-default-2-nodes-small
@@ -351,74 +397,92 @@ experiments:
     cpu: 3
     memory_gb: 8
     dataset_size: small
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-default-4-nodes-small
 
   - id: national-scale-spatial-join-databricks-default-2-nodes-medium
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-default-2-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: medium
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-default-4-nodes-medium
+      - national-scale-spatial-join-databricks-broadcast-2-nodes-medium
+      - national-scale-spatial-join-databricks-partitioned-2-nodes-medium
 
   - id: national-scale-spatial-join-databricks-default-2-nodes-large
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-default-2-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: large
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-default-16-nodes-large
 
   - id: national-scale-spatial-join-databricks-default-4-nodes-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-default-4-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-default-2-nodes-small
 
   - id: national-scale-spatial-join-databricks-default-4-nodes-medium
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-default-4-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: medium
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-broadcast-2-nodes-medium
+      - national-scale-spatial-join-databricks-partitioned-2-nodes-medium
+      - national-scale-spatial-join-databricks-default-2-nodes-medium
 
   - id: national-scale-spatial-join-databricks-default-4-nodes-large
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-default-4-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: large
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-default-12-nodes-large
 
   - id: national-scale-spatial-join-databricks-default-8-nodes-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-default-8-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: small
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-broadcast-4-nodes-small
+      - national-scale-spatial-join-databricks-partitioned-4-nodes-small
 
   - id: national-scale-spatial-join-databricks-default-8-nodes-medium
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-default-8-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: medium
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-broadcast-4-nodes-medium
+      - national-scale-spatial-join-databricks-partitioned-4-nodes-medium
 
   - id: national-scale-spatial-join-databricks-default-8-nodes-large
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-default-8-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: large
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-duckdb-large
+      - national-scale-spatial-join-postgis-large
 
   - id: national-scale-spatial-join-databricks-default-12-nodes-large
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-default-12-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: large
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-default-4-nodes-large
 
   - id: national-scale-spatial-join-databricks-default-16-nodes-large
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-default-16-nodes:latest
     cpu: 3
     memory_gb: 8
     dataset_size: large
-    related_script_ids: []
+    related_script_ids:
+      - national-scale-spatial-join-databricks-default-2-nodes-large

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ def main() -> None:
     benchmark run launches every experiment as a one-shot ACI, streams its logs
     until success or failure, and cleans up container groups before and after.
     """
-    _run_cmd(["az", "login", "--identity"])
+    _ensure_azure_login()
 
     with open(Config.BENCHMARK_FILE) as f:
         benchmark_configuration = yaml.safe_load(f)
@@ -142,6 +142,17 @@ def _container_group_name(experiment_id: str) -> str:
     budget = 63 - len("benchmark-") - 1 - len(digest)
     truncated = experiment_id[:budget].rstrip("-")
     return f"benchmark-{truncated}-{digest}"
+
+
+def _ensure_azure_login() -> None:
+    try:
+        _run_cmd(["az", "account", "show"], suppress_error_log=True)
+        logger.info("Azure CLI already authenticated; skipping managed-identity login.")
+        return
+    except RuntimeError:
+        pass
+
+    _run_cmd(["az", "login", "--identity"])
 
 
 # noinspection PyDeprecation


### PR DESCRIPTION
This pull request updates the benchmark batching and pairing logic, documentation, and configuration to reflect a new batching approach for experiments. Instead of simple pairs, experiments are now grouped into batches based on four explicit constraints, and the documentation and `benchmarks.yml` have been updated accordingly. These changes clarify the batching mechanism, update the experiment matrix, and ensure correct batch membership in the configuration.

**Documentation and batching logic updates:**

- **Batching invariant and constraints:**  
  The documentation in `CLAUDE.md` and `README.md` now describes that experiments are grouped into batches (not just pairs) using `related_script_ids`, with four constraints: same query type, same dataset size, at most one PostGIS member, and a Databricks vCPU cap per batch. The rationale and implementation details are clearly explained, and references to "pairing" have been replaced with "batching" throughout. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L26-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L155-R188)

- **Expanded batch matrix and listing:**  
  The experiment matrix in `README.md` has been updated to show 20 batches (instead of 40 pairs), and a detailed batch listing table is added, including batch type, size, Databricks vCPU usage, and members. The grouping logic for single-node and Sedona experiments within batches is clarified.

**Configuration updates:**

- **`benchmarks.yml` batch membership:**  
  The `related_script_ids` fields in `benchmarks.yml` for DuckDB and PostGIS experiments are updated to include the relevant Sedona experiments for each batch, ensuring that batch membership matches the new invariant and documentation. [[1]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R164-R165) [[2]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R174-R175) [[3]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R184-R185) [[4]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R194-R195) [[5]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R204) [[6]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R213)

- **Instructions for adding benchmarks:**  
  The instructions in `CLAUDE.md` for adding new benchmarks now specify that new entries must be assigned to a batch that satisfies the four constraints, and `dataset_size` is now an explicit required field.

These changes ensure that benchmark orchestration is fair, reproducible, and aligned with infrastructure constraints, and that both the documentation and configuration accurately reflect the current batching logic.