### PR TITLE
#293 Fix query_id strip for SMALL dataset

### DIFF
--- a/src/presentation/entrypoints/_factory.py
+++ b/src/presentation/entrypoints/_factory.py
@@ -21,10 +21,7 @@ def _get_dataset_size(
 def _build_query_id(base: str, dataset_size: DatasetSize) -> str:
     """
     Compose the ``query_id`` for a benchmark entrypoint from its base identifier and
-    the active dataset size. ``DatasetSize.SMALL`` returns the bare base so historical
-    SMALL-only run keys in blob storage remain accessible without renaming; other sizes
-    get a ``"-{size}"`` suffix so results stay keyed unambiguously.
+    the active dataset size. Always suffixed with ``"-{size}"`` so the resulting id
+    matches the ``benchmarks.yml`` experiment id and the Azure container resource name.
     """
-    if dataset_size is DatasetSize.SMALL:
-        return base
     return f"{base}-{dataset_size.value}"


### PR DESCRIPTION
## Summary

- Closes #293.
- `_build_query_id` no longer strips `-small` for `DatasetSize.SMALL`. `query_id` always carries the size suffix, matching `benchmarks.yml` ids and the Azure container resource name.
- Unblocks `_save_run_cost_analytics` for all SMALL benchmarks; same fix covers all queries/sizes.

## Test plan

- [ ] Re-run a SMALL benchmark (`point-in-polygon-lookup-postgis-small`) end-to-end; confirm `_save_run_cost_analytics` no longer raises.
- [ ] Verify ACI cost row and Postgres cost row land in blob storage under the new `<query>-small/` prefix.
- [ ] Spot-check a LARGE benchmark still passes (no regression from removing the special case).
- [ ] Delete or migrate pre-fix SMALL blob paths bare-keyed under `<query>/` (orchestrator-side cleanup, not in this PR).