### PR TITLE
Feature/292 create lower and upper bound for queries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Python, DuckDB (spatial), PostGIS on Azure Database for PostgreSQL, Apache Sedon
 - Secrets live in `.env` (gitignored) and are forwarded to ACI as `--secure-environment-variables` from `main.py`.
 - Benchmark batching: members of a batch list each other bidirectionally in `related_script_ids`. The orchestrator dedupes via `completed_experiments`, so each batch runs once as one parallel `ThreadPoolExecutor` fan-out. A batch must satisfy four constraints simultaneously: (a) same query type, (b) same `dataset_size`, (c) at most one PostGIS member (shared Azure Postgres server), (d) Databricks cluster vCPU sum ≤ 80, computed as `(workers + 1) × 4` per Sedona member on `Standard_D4s_v3`. See `README.md#pairing-and-randomization` for the full batch listing. *Why: peers must execute under the same wall-clock window for fair comparison, without contending on shared infrastructure or breaching regional quota.*
 - Adding a benchmark requires three edits in lockstep: file in `src/presentation/entrypoints/`, `case` arm in `benchmark_runner.py`, and an entry in `benchmarks.yml`. Missing any one silently breaks dispatch or orchestration.
+- Stopping rule on `@monitor`: high-frequency single-machine queries use sequential stopping (bootstrapped CI on the mean elapsed time, floors at `BENCHMARK_MIN_ITERATIONS` and `BENCHMARK_MIN_TIMED_WINDOW_SECONDS`, ceiling at the `BenchmarkIteration` value, hard timeout at `BENCHMARK_MAX_TIMED_WINDOW_SECONDS`). Long-running low-variance benchmarks (`national_scale_spatial_join_*` for Databricks, DuckDB, and PostGIS) opt out via `use_sequential_stopping=False` and run a small fixed iteration count. *Why: bootstrap CI on <10 samples is uninformative, and the per-iteration cost of those benchmarks (cluster time, shared Postgres) outweighs precision gains.* See `README.md#stopping-rule` for the full rule.
 
 ## Commands
 
@@ -39,6 +40,7 @@ python benchmark_runner.py --script-id <id> --benchmark-run 1 --run-id dev  # on
 - Create `src/presentation/entrypoints/<name>.py`; re-export from `entrypoints/__init__.py`.
 - Add `case "<script-id>":` in `benchmark_runner.py`.
 - Append entry to `benchmarks.yml` with `id`, `image`, `cpu`, `memory_gb`, `dataset_size`, `related_script_ids` (list peers both ways; assign to an existing batch that satisfies the four constraints in the batching invariant, or create a new batch).
+- Pick the stopping rule on `@monitor`: leave the default (`use_sequential_stopping=True`) for short-iteration queries where many samples are cheap; set `use_sequential_stopping=False` when each iteration is long-running and low-variance, or the per-iteration cost (cluster time, shared Postgres) makes additional iterations expensive.
 - If a new service is needed: contract in `application/contracts/`, impl in `infra/infrastructure/services/`, provider in `containers.py`.
 </important>
 

--- a/README.md
+++ b/README.md
@@ -96,18 +96,51 @@ as:
 
 1. **Warmup iterations** run `Config.BENCHMARK_WARMUP_ITERATIONS` times (default 5). Results are discarded. Warmup
    primes the OS page cache, DuckDB and PostgreSQL connection state, and any JIT-compiled hot paths in the engine.
-2. **Timed iterations** run a per-query count taken from the `BenchmarkIteration` enum (for example 1000 for `DB_SCAN`,
-   7 for `NATIONAL_SCALE_SPATIAL_JOIN`). Each iteration records:
+2. **Timed iterations** record per-iteration:
     - wall-clock elapsed time (`time.perf_counter`),
     - process CPU user and system seconds (`psutil.Process.cpu_times`),
     - container network bytes sent and received (`psutil.net_io_counters`),
     - result cardinality.
+   The loop stops via one of two rules depending on the benchmark (see [Stopping rule](#stopping-rule) below).
 3. **Cost analytics** are computed once per benchmark over the wall-clock window that covers the timed iterations only.
    Warmup is excluded. Pricing constants live in `src/infra/infrastructure/services/azure_pricing_service.py`, pinned
    to 2026 Norway East rates with source URLs and update notes.
 
 Per-iteration samples and per-benchmark cost rows are written as Parquet to the `benchmarks` blob container in a
 hive-partitioned layout, so downstream analysis can read full distributions rather than point averages.
+
+#### Stopping rule
+
+High-frequency single-machine queries (point-in-polygon lookup, kNN search, bbox filtering) use a **sequential
+stopping rule** so the iteration count is bound to measured variance rather than fixed up front. After every timed
+iteration the decorator computes a non-parametric bootstrapped 95% confidence interval on the mean elapsed time
+(`Config.BENCHMARK_BOOTSTRAP_RESAMPLES=1000` resamples drawn with replacement from the elapsed-time samples
+collected so far). The loop stops as soon as all of these hold:
+
+- at least `Config.BENCHMARK_MIN_ITERATIONS=10` iterations have completed (so the CI estimate is itself stable),
+- the timed window is at least `Config.BENCHMARK_MIN_TIMED_WINDOW_SECONDS=60` seconds (so the Azure Monitor
+  one-minute metric buckets that feed the cost model contain a usable data point), and
+- the bootstrapped CI half-width is within `Config.BENCHMARK_TARGET_CI_HALF_WIDTH_RELATIVE=0.05` of the sample mean
+  (5% relative precision).
+
+The per-query value in `BenchmarkIteration` (for example `POINT_IN_POLYGON_LOOKUP=2500`, `KNN_SEARCH=4000`) acts as
+an **upper bound** on iterations. If iterations hit the ceiling but the 60-second window floor has not yet been met,
+the loop continues past the ceiling and logs a one-time warning, so the cost-metric window stays valid. A separate
+hard cap `Config.BENCHMARK_MAX_TIMED_WINDOW_SECONDS=3600` (one hour) protects against runaway runs and trips
+`stop_reason="timeout"` if it fires. The bootstrap RNG is seeded deterministically from `(run_id, query_id)`
+(`blake2b` digest in `_make_bootstrap_rng`), so identical reruns reproduce the same stopping point.
+
+National-scale spatial joins (`national_scale_spatial_join_databricks_*`, `national_scale_spatial_join_duckdb`,
+`national_scale_spatial_join_postgis`) opt out via `use_sequential_stopping=False` on `@monitor` and run a small
+fixed count (`NATIONAL_SCALE_SPATIAL_JOIN=5`). These queries are long-running and low-variance: a bootstrapped CI on
+fewer than `MIN_ITERATIONS` samples would be uninformative, and the cost of additional iterations is significant on
+Databricks (cluster runtime × workers) and on the shared Postgres instance. The wall-clock timeout is also skipped
+for this branch, so the fixed iteration count is the only upper bound on these benchmarks.
+
+The achieved iteration count, mean, median, bootstrapped CI half-width (both absolute seconds and as a fraction of
+the mean), and `stop_reason` (`precision`, `timeout`, `ceiling`, `fixed`, or `failed`) are persisted alongside the
+existing identifiers in `benchmark_metadata.parquet`, so downstream analysis can filter or report on each benchmark's
+stopping condition.
 
 ### Engines under test
 

--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -224,6 +224,12 @@ def monitor(
                         ],
                     )
 
+                    if not use_sequential_stopping:
+                        if iteration >= ceiling:
+                            stop_reason = StopReason.FIXED
+                            break
+                        continue
+
                     window_seconds = (
                         datetime.datetime.now(datetime.UTC) - timed_loop_start
                     ).total_seconds()
@@ -237,12 +243,6 @@ def monitor(
                             f"iterations; stopping. Results may be underpowered."
                         )
                         break
-
-                    if not use_sequential_stopping:
-                        if iteration >= ceiling:
-                            stop_reason = StopReason.FIXED
-                            break
-                        continue
 
                     floor_met = (
                         window_seconds >= Config.BENCHMARK_MIN_TIMED_WINDOW_SECONDS

--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -10,9 +10,16 @@ from src.application.common.monitor_utils import (
     _save_run,
     _save_run_metadata,
     _save_run_cost_analytics,
+    _bootstrap_ci_half_width,
+    _make_bootstrap_rng,
 )
 from src.application.dtos import CostConfiguration, DatabricksRunResult
-from src.domain.enums import BenchmarkIteration, BlobOperationType, SchemaVersion
+from src.domain.enums import (
+    BenchmarkIteration,
+    BlobOperationType,
+    SchemaVersion,
+    StopReason,
+)
 
 
 def monitor(
@@ -21,15 +28,27 @@ def monitor(
     cost_configuration: CostConfiguration,
     skip_warmup: bool = False,
     elapsed_from_result: bool = False,
+    use_sequential_stopping: bool = True,
 ):
     """
     Benchmarking decorator. Wraps a function in warmup + timed iterations, records
     per-iteration samples, and writes run metadata and cost analytics to blob storage.
     :param query_id: Identifier for the benchmarked query.
-    :param benchmark_iteration: Number of timed iterations to run.
+    :param benchmark_iteration: Hard ceiling on timed iterations. Under the sequential
+        stopping rule this acts as an upper bound; the loop typically stops earlier once
+        the bootstrapped CI on the mean elapsed time is within the configured precision
+        and the 60-second timed-window floor is met.
     :param cost_configuration: Which Azure cost components to compute and store.
     :param skip_warmup: Disable warmup runs. Use for Databricks, since each run provisions a cluster and warmup would multiply cost. Default is False.
     :param elapsed_from_result: Treat the wrapped function's return value as a (elapsed_seconds, cardinality) tuple instead of using wall-clock time and len(result). Use for Databricks, since the notebook self-reports both. Default is False.
+    :param use_sequential_stopping: Run iterations until the bootstrapped CI half-width
+        on the mean elapsed time falls within ``Config.BENCHMARK_TARGET_CI_HALF_WIDTH_RELATIVE``,
+        bounded below by ``Config.BENCHMARK_MIN_ITERATIONS`` and
+        ``Config.BENCHMARK_MIN_TIMED_WINDOW_SECONDS``, and above by ``benchmark_iteration``
+        (soft ceiling: kept open until the 60-second floor is met to keep the cost-metric
+        window valid) and ``Config.BENCHMARK_MAX_TIMED_WINDOW_SECONDS`` (hard timeout).
+        Set to False for Databricks national-scale runs, which use a fixed iteration count.
+        Default is True.
     """
 
     def decorator(func):
@@ -44,6 +63,7 @@ def monitor(
                 f"Starting benchmark for query '{query_id}' with run ID '{run_id}'."
             )
 
+            ceiling = benchmark_iteration.value
             ingress_sum: int = 0
             egress_sum: int = 0
             start_time = datetime.datetime.now(datetime.UTC)
@@ -55,7 +75,7 @@ def monitor(
 
             if skip_warmup:
                 logger.info(
-                    f"Executing {benchmark_iteration.value} benchmark run(s) (no warmup)."
+                    f"Executing benchmark for '{query_id}' with no warmup (ceiling={ceiling})."
                 )
             else:
                 logger.info(
@@ -91,13 +111,29 @@ def monitor(
                         )
                         break
                 if failure is None:
-                    logger.info(
-                        f"Warmup runs completed. Starting {benchmark_iteration.value} benchmark runs."
-                    )
+                    if use_sequential_stopping:
+                        logger.info(
+                            f"Warmup complete for '{query_id}'. Starting sequential timed iterations "
+                            f"(min={Config.BENCHMARK_MIN_ITERATIONS}, ceiling={ceiling}, "
+                            f"min_window={Config.BENCHMARK_MIN_TIMED_WINDOW_SECONDS}s, "
+                            f"max_window={Config.BENCHMARK_MAX_TIMED_WINDOW_SECONDS}s, "
+                            f"target_ci_relative={Config.BENCHMARK_TARGET_CI_HALF_WIDTH_RELATIVE})."
+                        )
+                    else:
+                        logger.info(
+                            f"Warmup complete for '{query_id}'. Starting {ceiling} fixed timed iterations."
+                        )
+
+            elapsed_samples: list[float] = []
+            bootstrap_rng = _make_bootstrap_rng(run_id=run_id, query_id=query_id)
+            stop_reason: StopReason | None = None
+            soft_ceiling_warned = False
+            timed_loop_start = datetime.datetime.now(datetime.UTC)
 
             if failure is None:
-                for i in range(benchmark_iteration.value):
-                    iteration = i + 1
+                iteration = 0
+                while True:
+                    iteration += 1
 
                     started_at = datetime.datetime.now(datetime.UTC)
                     (
@@ -129,6 +165,7 @@ def monitor(
                             f"Iteration {iteration} raised for query '{query_id}': "
                             f"{iter_exc!r}. Failing fast; skipping remaining iterations."
                         )
+                        stop_reason = StopReason.FAILED
                         break
 
                     executor_input_bytes_read = None
@@ -156,13 +193,14 @@ def monitor(
 
                     ingress_sum += net_bytes_received
                     egress_sum += net_bytes_sent
+                    elapsed_samples.append(elapsed_time)
 
                     _save_run(
                         run_id=run_id,
                         benchmark_run=benchmark_run,
                         query_id=query_id,
                         iteration=iteration,
-                        total_iterations=benchmark_iteration.value,
+                        total_iterations=ceiling,
                         samples=[
                             {
                                 "status": "success",
@@ -186,6 +224,68 @@ def monitor(
                         ],
                     )
 
+                    window_seconds = (
+                        datetime.datetime.now(datetime.UTC) - timed_loop_start
+                    ).total_seconds()
+
+                    if window_seconds >= Config.BENCHMARK_MAX_TIMED_WINDOW_SECONDS:
+                        stop_reason = StopReason.TIMEOUT
+                        logger.warning(
+                            f"Timed window for '{query_id}' reached "
+                            f"BENCHMARK_MAX_TIMED_WINDOW_SECONDS="
+                            f"{Config.BENCHMARK_MAX_TIMED_WINDOW_SECONDS}s after {iteration} "
+                            f"iterations; stopping. Results may be underpowered."
+                        )
+                        break
+
+                    if not use_sequential_stopping:
+                        if iteration >= ceiling:
+                            stop_reason = StopReason.FIXED
+                            break
+                        continue
+
+                    floor_met = (
+                        window_seconds >= Config.BENCHMARK_MIN_TIMED_WINDOW_SECONDS
+                    )
+                    if (
+                        iteration >= Config.BENCHMARK_MIN_ITERATIONS
+                        and floor_met
+                    ):
+                        mean, _median, half_width = _bootstrap_ci_half_width(
+                            samples=elapsed_samples,
+                            n_resamples=Config.BENCHMARK_BOOTSTRAP_RESAMPLES,
+                            confidence=Config.BENCHMARK_CI_CONFIDENCE,
+                            rng=bootstrap_rng,
+                        )
+                        if mean > 0 and (
+                            half_width / mean
+                            <= Config.BENCHMARK_TARGET_CI_HALF_WIDTH_RELATIVE
+                        ):
+                            stop_reason = StopReason.PRECISION
+                            logger.info(
+                                f"Precision target met for '{query_id}' at iteration "
+                                f"{iteration} (mean={mean:.4f}s, half_width={half_width:.4f}s, "
+                                f"relative={half_width / mean:.4f})."
+                            )
+                            break
+
+                    if iteration >= ceiling:
+                        if floor_met:
+                            stop_reason = StopReason.CEILING
+                            logger.info(
+                                f"Iteration ceiling {ceiling} reached for '{query_id}' "
+                                f"with window {window_seconds:.1f}s; stopping."
+                            )
+                            break
+                        if not soft_ceiling_warned:
+                            logger.warning(
+                                f"Iteration ceiling {ceiling} reached for '{query_id}' but "
+                                f"timed window only {window_seconds:.1f}s "
+                                f"(< {Config.BENCHMARK_MIN_TIMED_WINDOW_SECONDS}s). "
+                                f"Continuing past ceiling so the cost-metric window stays valid."
+                            )
+                            soft_ceiling_warned = True
+
             if failure is not None:
                 assert failure_started_at is not None
                 assert failure_ended_at is not None
@@ -195,7 +295,7 @@ def monitor(
                     benchmark_run=benchmark_run,
                     query_id=query_id,
                     iteration=failure_iteration or 1,
-                    total_iterations=benchmark_iteration.value,
+                    total_iterations=ceiling,
                     samples=[
                         {
                             "status": "failed",
@@ -219,12 +319,48 @@ def monitor(
                     ],
                 )
 
+            if stop_reason is None:
+                stop_reason = (
+                    StopReason.FIXED if not use_sequential_stopping else StopReason.FAILED
+                )
+
+            if elapsed_samples:
+                final_mean, final_median, final_half_width = _bootstrap_ci_half_width(
+                    samples=elapsed_samples,
+                    n_resamples=Config.BENCHMARK_BOOTSTRAP_RESAMPLES,
+                    confidence=Config.BENCHMARK_CI_CONFIDENCE,
+                    rng=bootstrap_rng,
+                )
+            else:
+                final_mean = None
+                final_median = None
+                final_half_width = None
+
+            if use_sequential_stopping and final_mean is not None and final_mean > 0:
+                ci_half_width_relative = final_half_width / final_mean
+                ci_half_width_seconds = final_half_width
+            else:
+                ci_half_width_relative = None
+                ci_half_width_seconds = None
+
+            achieved_iterations = len(elapsed_samples)
+
             end_time = datetime.datetime.now(datetime.UTC)
             logger.info(
-                f"Benchmark runs completed in {round((end_time - start_time).total_seconds(), 2)} seconds."
+                f"Benchmark runs completed in {round((end_time - start_time).total_seconds(), 2)} "
+                f"seconds (achieved_iterations={achieved_iterations}, stop_reason={stop_reason.value})."
             )
 
-            _save_run_metadata(query_id=query_id, run_id=run_id)
+            _save_run_metadata(
+                query_id=query_id,
+                run_id=run_id,
+                achieved_iterations=achieved_iterations,
+                stop_reason=stop_reason,
+                ci_half_width_seconds=ci_half_width_seconds,
+                ci_half_width_relative=ci_half_width_relative,
+                mean_elapsed_seconds=final_mean,
+                median_elapsed_seconds=final_median,
+            )
             _save_run_cost_analytics(
                 run_id=run_id,
                 cost_configuration=cost_configuration,

--- a/src/application/common/monitor_cpu_and_ram.py
+++ b/src/application/common/monitor_cpu_and_ram.py
@@ -9,7 +9,7 @@ import psutil
 from src import Config
 from src.application.common import logger
 from src.application.common.monitor_utils import _get_run_id, _get_benchmark_run, _save_run_metadata, _save_run
-from src.domain.enums import BenchmarkIteration
+from src.domain.enums import BenchmarkIteration, StopReason
 
 
 def monitor_cpu_and_ram(
@@ -80,7 +80,16 @@ def monitor_cpu_and_ram(
 
             end_time = datetime.datetime.now(datetime.UTC)
             logger.info(f"Benchmarking completed in {round((end_time - start_time).total_seconds(), 2)} seconds.")
-            _save_run_metadata(query_id=query_id, run_id=run_id)
+            _save_run_metadata(
+                query_id=query_id,
+                run_id=run_id,
+                achieved_iterations=benchmark_iteration.value,
+                stop_reason=StopReason.FIXED,
+                ci_half_width_seconds=None,
+                ci_half_width_relative=None,
+                mean_elapsed_seconds=None,
+                median_elapsed_seconds=None,
+            )
             logger.info(f"Benchmark run {benchmark_run} completed.")
             return result
 

--- a/src/application/common/monitor_utils.py
+++ b/src/application/common/monitor_utils.py
@@ -73,6 +73,12 @@ def _save_run(
 def _save_run_metadata(
     query_id: str,
     run_id: str,
+    achieved_iterations: int,
+    stop_reason: StopReason,
+    ci_half_width_seconds: float | None,
+    ci_half_width_relative: float | None,
+    mean_elapsed_seconds: float | None,
+    median_elapsed_seconds: float | None,
     monitoring_storage_service: IMonitoringStorageService = Provide[
         Containers.monitoring_storage_service
     ],
@@ -81,7 +87,16 @@ def _save_run_metadata(
     metadata_id = str(uuid.uuid4())
     timestamp = datetime.datetime.now(datetime.timezone.utc)
     monitoring_storage_service.write_metadata_to_blob_storage(
-        metadata_id=metadata_id, timestamp=timestamp, query_id=query_id, run_id=run_id
+        metadata_id=metadata_id,
+        timestamp=timestamp,
+        query_id=query_id,
+        run_id=run_id,
+        achieved_iterations=achieved_iterations,
+        stop_reason=stop_reason,
+        ci_half_width_seconds=ci_half_width_seconds,
+        ci_half_width_relative=ci_half_width_relative,
+        mean_elapsed_seconds=mean_elapsed_seconds,
+        median_elapsed_seconds=median_elapsed_seconds,
     )
 
     logger.info(f"Benchmark metadata saved with ID '{metadata_id}'.")

--- a/src/application/common/monitor_utils.py
+++ b/src/application/common/monitor_utils.py
@@ -1,4 +1,5 @@
 ﻿import datetime
+import hashlib
 import random
 import string
 import time
@@ -6,6 +7,7 @@ import uuid
 from datetime import date
 from typing import Any
 
+import numpy as np
 import psutil
 from dependency_injector.wiring import inject, Provide
 
@@ -13,7 +15,7 @@ from src import Config
 from src.application.common import logger
 from src.application.contracts import IMonitoringStorageService, IAzureCostService
 from src.application.dtos import CostConfiguration
-from src.domain.enums import BlobOperationType
+from src.domain.enums import BlobOperationType, StopReason
 from src.infra.infrastructure import Containers
 
 
@@ -163,6 +165,39 @@ def _create_global_iteration(
     iteration: int, total_iterations: int, benchmark_run: int
 ) -> int:
     return iteration + total_iterations * (benchmark_run - 1)
+
+
+def _make_bootstrap_rng(run_id: str, query_id: str) -> np.random.Generator:
+    """
+    Deterministic seed for bootstrap resampling per (run_id, query_id), so the
+    stopping rule is reproducible across reruns of the same benchmark.
+    """
+    digest = hashlib.blake2b(
+        f"{run_id}::{query_id}".encode(), digest_size=8
+    ).digest()
+    seed = int.from_bytes(digest, "big")
+    return np.random.default_rng(seed)
+
+
+def _bootstrap_ci_half_width(
+    samples: list[float],
+    n_resamples: int,
+    confidence: float,
+    rng: np.random.Generator,
+) -> tuple[float, float, float]:
+    """
+    Non-parametric bootstrap CI on the sample mean. Returns
+    (mean, median, abs_half_width_on_mean).
+    """
+    arr = np.asarray(samples, dtype=np.float64)
+    n = arr.size
+    indices = rng.integers(0, n, size=(n_resamples, n))
+    resample_means = arr[indices].mean(axis=1)
+    alpha = 1.0 - confidence
+    lower = float(np.quantile(resample_means, alpha / 2.0))
+    upper = float(np.quantile(resample_means, 1.0 - alpha / 2.0))
+    half_width = (upper - lower) / 2.0
+    return float(arr.mean()), float(np.median(arr)), half_width
 
 
 def _measure_io(

--- a/src/application/contracts/monitoring_storage_service.py
+++ b/src/application/contracts/monitoring_storage_service.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from src.application.dtos import Cost
+from src.domain.enums import StopReason
 
 
 class IMonitoringStorageService(ABC):
@@ -12,7 +13,13 @@ class IMonitoringStorageService(ABC):
             metadata_id: str,
             timestamp: datetime.datetime,
             query_id: str,
-            run_id: str
+            run_id: str,
+            achieved_iterations: int,
+            stop_reason: StopReason,
+            ci_half_width_seconds: float | None,
+            ci_half_width_relative: float | None,
+            mean_elapsed_seconds: float | None,
+            median_elapsed_seconds: float | None,
     ) -> None:
         """
         Save metadata to blob storage. Metadata includes information about the query and the run,
@@ -26,6 +33,18 @@ class IMonitoringStorageService(ABC):
             main method and passed to this method.
         :param query_id: Query ID associated with the run which is passed from the main method.
         :param run_id: A unique identifier for the run.
+        :param achieved_iterations: Number of timed iterations actually executed (excludes warmup).
+        :param stop_reason: Why the iteration loop stopped (precision met, timeout, ceiling, fixed
+            count for Databricks, or failed).
+        :param ci_half_width_seconds: Absolute half-width of the bootstrapped 95% CI on the mean
+            elapsed time, in seconds. None when sequential stopping is disabled or the run failed
+            before producing enough samples.
+        :param ci_half_width_relative: Same half-width as a fraction of the mean (e.g. 0.05 == 5%).
+            None when undefined.
+        :param mean_elapsed_seconds: Mean elapsed time across timed iterations. None when no timed
+            iteration completed.
+        :param median_elapsed_seconds: Median elapsed time across timed iterations. None when no
+            timed iteration completed.
         :return: None
         """
         raise NotImplementedError

--- a/src/config.py
+++ b/src/config.py
@@ -115,6 +115,14 @@ class Config:
     BENCHMARK_METADATA_BLOB_NAME: str = "benchmark_metadata.parquet"
     BENCHMARK_DOPPA_DATA_RELEASE: str = "2026-05-16.1"
 
+    # Sequential stopping rule (bootstrapped CI on mean elapsed time)
+    BENCHMARK_MIN_ITERATIONS: int = 10
+    BENCHMARK_MIN_TIMED_WINDOW_SECONDS: int = 60
+    BENCHMARK_MAX_TIMED_WINDOW_SECONDS: int = 3600
+    BENCHMARK_TARGET_CI_HALF_WIDTH_RELATIVE: float = 0.05
+    BENCHMARK_BOOTSTRAP_RESAMPLES: int = 1000
+    BENCHMARK_CI_CONFIDENCE: float = 0.95
+
     INGESTION_DELAY_SECONDS: int = 600
 
     # DATABRICKS

--- a/src/domain/enums/__init__.py
+++ b/src/domain/enums/__init__.py
@@ -12,3 +12,4 @@ from .data_source import DataSource
 from .dataset_size import DatasetSize
 from .bounding_box import BoundingBox
 from .schema_version import SchemaVersion
+from .stop_reason import StopReason

--- a/src/domain/enums/stop_reason.py
+++ b/src/domain/enums/stop_reason.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class StopReason(Enum):
+    PRECISION = "precision"
+    TIMEOUT = "timeout"
+    CEILING = "ceiling"
+    FIXED = "fixed"
+    FAILED = "failed"

--- a/src/infra/infrastructure/services/monitoring_storage_service.py
+++ b/src/infra/infrastructure/services/monitoring_storage_service.py
@@ -6,7 +6,7 @@ import pandas as pd
 from src import Config
 from src.application.contracts import IMonitoringStorageService, IBlobStorageService, IBytesService, IFilePathService
 from src.application.dtos import Cost
-from src.domain.enums import StorageContainer
+from src.domain.enums import StorageContainer, StopReason
 
 
 class MonitoringStorageService(IMonitoringStorageService):
@@ -29,7 +29,13 @@ class MonitoringStorageService(IMonitoringStorageService):
             metadata_id: str,
             timestamp: datetime.datetime,
             query_id: str,
-            run_id: str
+            run_id: str,
+            achieved_iterations: int,
+            stop_reason: StopReason,
+            ci_half_width_seconds: float | None,
+            ci_half_width_relative: float | None,
+            mean_elapsed_seconds: float | None,
+            median_elapsed_seconds: float | None,
     ) -> None:
         benchmark_metadata_file = self.__blob_storage_service.download_file(
             container_name=StorageContainer.METADATA,
@@ -44,7 +50,13 @@ class MonitoringStorageService(IMonitoringStorageService):
             "id": metadata_id,
             "timestamp": pd.Timestamp(timestamp),
             "query_id": query_id,
-            "run_id": run_id
+            "run_id": run_id,
+            "achieved_iterations": achieved_iterations,
+            "stop_reason": stop_reason.value,
+            "ci_half_width_seconds": ci_half_width_seconds,
+            "ci_half_width_relative": ci_half_width_relative,
+            "mean_elapsed_seconds": mean_elapsed_seconds,
+            "median_elapsed_seconds": median_elapsed_seconds,
         }])
 
         updated_benchmark_df = pd.concat(

--- a/src/presentation/entrypoints/_databricks_benchmark_runner.py
+++ b/src/presentation/entrypoints/_databricks_benchmark_runner.py
@@ -66,6 +66,7 @@ def _build_benchmark_fn(
         ),
         skip_warmup=False,
         elapsed_from_result=True,
+        use_sequential_stopping=False,
     )
     def _benchmark(
         cluster_id: str,

--- a/src/presentation/entrypoints/national_scale_spatial_join_duckdb.py
+++ b/src/presentation/entrypoints/national_scale_spatial_join_duckdb.py
@@ -33,6 +33,7 @@ def _build_benchmark_fn(dataset_size: DatasetSize):
         query_id=query_id,
         benchmark_iteration=BenchmarkIteration.NATIONAL_SCALE_SPATIAL_JOIN,
         cost_configuration=CostConfiguration(include_aci=True, include_blob_storage=True),
+        use_sequential_stopping=False,
     )
     def _benchmark(
         db_context: DuckDBPyConnection,

--- a/src/presentation/entrypoints/national_scale_spatial_join_postgis.py
+++ b/src/presentation/entrypoints/national_scale_spatial_join_postgis.py
@@ -67,6 +67,7 @@ def _build_benchmark_fn(dataset_size: DatasetSize):
         query_id=query_id,
         benchmark_iteration=BenchmarkIteration.NATIONAL_SCALE_SPATIAL_JOIN,
         cost_configuration=CostConfiguration(include_aci=True, include_postgres=True),
+        use_sequential_stopping=False,
     )
     def _benchmark(
         db_context: Engine,


### PR DESCRIPTION
This pull request introduces a new, configurable stopping rule for benchmarks, allowing for more precise and efficient execution of timed iterations. The main change is the implementation of a sequential stopping rule based on bootstrapped confidence intervals for high-frequency queries, with an opt-out for long-running, low-variance benchmarks. The documentation and metadata handling have also been updated to reflect and support these changes.

**Benchmark stopping rule improvements:**

* Added a sequential stopping rule to the `monitor` decorator in `monitor.py`, which stops benchmark iterations early if a bootstrapped confidence interval on the mean elapsed time meets a configured precision, subject to minimum iteration and time windows, and a ceiling based on the `BenchmarkIteration` value. Long-running benchmarks can opt out and use a fixed iteration count instead. The stopping reason and achieved iterations are now logged and saved as metadata. [[1]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR31-R51) [[2]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR114-R136) [[3]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR227-R288) [[4]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR322-R363)

**Documentation updates:**

* Updated `README.md` and `CLAUDE.md` to document the new stopping rule, its rationale, and how to configure it for different benchmarks. This includes details on the bootstrapped CI procedure, configuration parameters, and when to use fixed vs. sequential stopping. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L99-R144) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R28) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R43)

**Metadata and logging enhancements:**

* Modified `_save_run_metadata` calls in both `monitor.py` and `monitor_cpu_and_ram.py` to record additional metadata: achieved iterations, stopping reason, CI half-width, and summary statistics (mean/median elapsed time). [[1]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR322-R363) [[2]](diffhunk://#diff-f2c9655ad7d66dada064a65fd238dc7a6ff0f66fb4442f5d6164f10fd1235480L83-R92)

**Supporting code and enum changes:**

* Added `StopReason` enum and updated imports throughout to support new stopping logic and metadata. [[1]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR13-R22) [[2]](diffhunk://#diff-f2c9655ad7d66dada064a65fd238dc7a6ff0f66fb4442f5d6164f10fd1235480L12-R12) [[3]](diffhunk://#diff-47aa54462bfb662354ffd8d94d9b3c69743ab69838339174abf1925081c10617R2-R18)

**Refactoring and code clarity:**

* Refactored the iteration loop in `monitor.py` for clarity, separating sequential and fixed stopping logic, and improved logging to make benchmark progress and stopping conditions more transparent. [[1]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR66) [[2]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fL58-R78) [[3]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR168) [[4]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR196-R203) [[5]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fL198-R298)