### PR TITLE
#310 Record stop_reason=failed on warmup or iter failure

### DIFF
--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -331,7 +331,9 @@ def monitor(
                     ],
                 )
 
-            if stop_reason is None:
+            if failure is not None:
+                stop_reason = StopReason.FAILED
+            elif stop_reason is None:
                 stop_reason = (
                     StopReason.FIXED if not use_sequential_stopping else StopReason.FAILED
                 )


### PR DESCRIPTION
## Summary
- When a benchmark fails during warmup, the `@monitor` decorator now records `stop_reason=failed` regardless of `use_sequential_stopping`. Previously the non-sequential branch (Databricks national-scale + DuckDB/PostGIS national-scale) fell through to `stop_reason=fixed` even when no timed iteration ran.
- The fallback now applies only on the success path: failure paths always set `failed`.
- Closes #310.

## Test plan
- [ ] Trigger a warmup failure on a non-sequential benchmark (e.g. Databricks `default-2-nodes-large`); confirm `benchmark_metadata.parquet` records `stop_reason=failed` and `achieved_iterations=0`.
- [ ] Run a healthy non-sequential benchmark (e.g. Databricks `broadcast-4-nodes-large`); confirm `stop_reason=fixed` and `achieved_iterations=5`.
- [ ] Run a sequential benchmark to completion (PIP small); confirm `stop_reason=precision` still records correctly.
- [ ] Force a timed-iter failure mid-run on a sequential benchmark; confirm `stop_reason=failed` and partial samples persist.