### PR TITLE
#327 Fix partitioned spatial join fallback to BroadcastNestedLoopJoin

### DIFF
--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -271,16 +271,16 @@ def monitor(
                             ],
                         )
 
-                    if elapsed_time >= Config.BENCHMARK_MAX_TIMED_WINDOW_SECONDS:
-                        stop_reason = StopReason.TIMEOUT
-                        logger.warning(
-                            f"Single iteration of '{query_id}' took "
-                            f"{elapsed_time:.1f}s, exceeding "
-                            f"BENCHMARK_MAX_TIMED_WINDOW_SECONDS="
-                            f"{Config.BENCHMARK_MAX_TIMED_WINDOW_SECONDS}s; "
-                            f"stopping."
-                        )
-                        break
+                        if elapsed_time >= Config.BENCHMARK_MAX_TIMED_WINDOW_SECONDS:
+                            stop_reason = StopReason.TIMEOUT
+                            logger.warning(
+                                f"Single iteration of '{query_id}' took "
+                                f"{elapsed_time:.1f}s, exceeding "
+                                f"BENCHMARK_MAX_TIMED_WINDOW_SECONDS="
+                                f"{Config.BENCHMARK_MAX_TIMED_WINDOW_SECONDS}s; "
+                                f"stopping."
+                            )
+                            break
 
                     if not use_sequential_stopping:
                         if iteration >= ceiling:

--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -271,6 +271,17 @@ def monitor(
                             ],
                         )
 
+                    if elapsed_time >= Config.BENCHMARK_MAX_TIMED_WINDOW_SECONDS:
+                        stop_reason = StopReason.TIMEOUT
+                        logger.warning(
+                            f"Single iteration of '{query_id}' took "
+                            f"{elapsed_time:.1f}s, exceeding "
+                            f"BENCHMARK_MAX_TIMED_WINDOW_SECONDS="
+                            f"{Config.BENCHMARK_MAX_TIMED_WINDOW_SECONDS}s; "
+                            f"stopping."
+                        )
+                        break
+
                     if not use_sequential_stopping:
                         if iteration >= ceiling:
                             stop_reason = StopReason.FIXED

--- a/src/infra/infrastructure/services/databricks_service.py
+++ b/src/infra/infrastructure/services/databricks_service.py
@@ -152,6 +152,13 @@ class DatabricksService(IDatabricksService):
                 "spark.driver.memoryOverhead": Config.DATABRICKS_DRIVER_MEMORY_OVERHEAD,
                 f"spark.hadoop.fs.azure.account.auth.type.{Config.AZURE_BLOB_STORAGE_ACCOUNT_NAME}.dfs.core.windows.net": "SharedKey",
                 f"spark.hadoop.fs.azure.account.key.{Config.AZURE_BLOB_STORAGE_ACCOUNT_NAME}.dfs.core.windows.net": Config.AZURE_BLOB_STORAGE_ACCOUNT_KEY,
+                # Photon bypasses Sedona's custom Catalyst strategies
+                # (JoinQueryDetector), causing spatial joins to fall back to
+                # BroadcastNestedLoopJoin. Disabling it lets
+                # SedonaContext.create(spark) register extraStrategies that
+                # the classic Spark planner respects.
+                "spark.databricks.photon.enabled": "false",
+                "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
             },
         }
         response = requests.post(

--- a/src/presentation/databricks/national_scale_spatial_join_broadcast.py
+++ b/src/presentation/databricks/national_scale_spatial_join_broadcast.py
@@ -30,6 +30,7 @@
 import json
 import time
 
+from pyspark.sql import functions as F
 from pyspark.sql.functions import broadcast
 from sedona.spark import SedonaContext
 
@@ -78,9 +79,6 @@ print(f"Cluster parallelism: {parallelism}")
 print(f"Buildings partitions before repartition: {buildings_df.rdd.getNumPartitions()}")
 
 buildings_df = buildings_df.repartition(parallelism)
-
-buildings_df.createOrReplaceTempView("buildings")
-municipalities_df.createOrReplaceTempView("municipalities")
 
 # COMMAND ----------
 
@@ -143,16 +141,16 @@ municipalities_df.createOrReplaceTempView("municipalities")
 
 start_time = time.perf_counter()
 
-result = sedona.sql("""
-    SELECT
-        m.municipality_name,
-        COUNT(b.geometry) AS building_count
-    FROM buildings b
-    JOIN municipalities m
-      ON ST_Intersects(m.geometry, b.geometry)
-    GROUP BY m.municipality_name
-    ORDER BY building_count DESC
-""")
+result = (
+    buildings_df.alias("b")
+    .join(
+        municipalities_df.alias("m"),
+        F.expr("ST_Intersects(m.geometry, b.geometry)"),
+    )
+    .groupBy(F.col("m.municipality_name"))
+    .agg(F.count(F.col("b.geometry")).alias("building_count"))
+    .orderBy(F.desc("building_count"))
+)
 
 cardinality = result.count()
 elapsed_seconds = time.perf_counter() - start_time
@@ -161,8 +159,6 @@ print(f"Spatial join complete. Regions with matched buildings: {cardinality}")
 print(f"Elapsed seconds: {elapsed_seconds:.3f}")
 
 # COMMAND ----------
-
-from pyspark.sql import functions as F
 
 _STAGE_DURATION_CAP = 100
 

--- a/src/presentation/databricks/national_scale_spatial_join_default.py
+++ b/src/presentation/databricks/national_scale_spatial_join_default.py
@@ -35,6 +35,7 @@
 import json
 import time
 
+from pyspark.sql import functions as F
 from sedona.spark import SedonaContext
 
 # COMMAND ----------
@@ -80,9 +81,6 @@ print(f"Cluster parallelism: {parallelism}")
 print(f"Buildings partitions before repartition: {buildings_df.rdd.getNumPartitions()}")
 
 buildings_df = buildings_df.repartition(parallelism)
-
-buildings_df.createOrReplaceTempView("buildings")
-municipalities_df.createOrReplaceTempView("municipalities")
 
 # COMMAND ----------
 
@@ -145,16 +143,16 @@ municipalities_df.createOrReplaceTempView("municipalities")
 
 start_time = time.perf_counter()
 
-result = sedona.sql("""
-    SELECT
-        m.municipality_name,
-        COUNT(b.geometry) AS building_count
-    FROM buildings b
-    JOIN municipalities m
-      ON ST_Intersects(m.geometry, b.geometry)
-    GROUP BY m.municipality_name
-    ORDER BY building_count DESC
-""")
+result = (
+    buildings_df.alias("b")
+    .join(
+        municipalities_df.alias("m"),
+        F.expr("ST_Intersects(m.geometry, b.geometry)"),
+    )
+    .groupBy(F.col("m.municipality_name"))
+    .agg(F.count(F.col("b.geometry")).alias("building_count"))
+    .orderBy(F.desc("building_count"))
+)
 
 cardinality = result.count()
 elapsed_seconds = time.perf_counter() - start_time
@@ -163,8 +161,6 @@ print(f"Spatial join complete. Regions with matched buildings: {cardinality}")
 print(f"Elapsed seconds: {elapsed_seconds:.3f}")
 
 # COMMAND ----------
-
-from pyspark.sql import functions as F
 
 _STAGE_DURATION_CAP = 100
 

--- a/src/presentation/databricks/national_scale_spatial_join_partitioned.py
+++ b/src/presentation/databricks/national_scale_spatial_join_partitioned.py
@@ -157,26 +157,27 @@ _original_broadcast_threshold = spark.conf.get("spark.sql.autoBroadcastJoinThres
 spark.conf.set("spark.sql.adaptive.enabled", "false")
 spark.conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
 
-start_time = time.perf_counter()
+try:
+    start_time = time.perf_counter()
 
-result = (
-    municipalities_df.alias("m")
-    .join(
-        buildings_df.alias("b"),
-        F.expr("ST_Intersects(m.geometry, b.geometry)"),
+    result = (
+        municipalities_df.alias("m")
+        .join(
+            buildings_df.alias("b"),
+            F.expr("ST_Intersects(m.geometry, b.geometry)"),
+        )
+        .groupBy(F.col("m.municipality_name"))
+        .agg(F.count(F.col("b.geometry")).alias("building_count"))
+        .orderBy(F.desc("building_count"))
     )
-    .groupBy(F.col("m.municipality_name"))
-    .agg(F.count(F.col("b.geometry")).alias("building_count"))
-    .orderBy(F.desc("building_count"))
-)
-cardinality = result.count()
-elapsed_seconds = time.perf_counter() - start_time
+    cardinality = result.count()
+    elapsed_seconds = time.perf_counter() - start_time
 
-spark.conf.set("spark.sql.adaptive.enabled", _original_aqe)
-spark.conf.set("spark.sql.autoBroadcastJoinThreshold", _original_broadcast_threshold)
-
-print(f"Spatial join complete. Regions with matched buildings: {cardinality}")
-print(f"Elapsed seconds: {elapsed_seconds:.3f}")
+    print(f"Spatial join complete. Regions with matched buildings: {cardinality}")
+    print(f"Elapsed seconds: {elapsed_seconds:.3f}")
+finally:
+    spark.conf.set("spark.sql.adaptive.enabled", _original_aqe)
+    spark.conf.set("spark.sql.autoBroadcastJoinThreshold", _original_broadcast_threshold)
 
 # COMMAND ----------
 

--- a/src/presentation/databricks/national_scale_spatial_join_partitioned.py
+++ b/src/presentation/databricks/national_scale_spatial_join_partitioned.py
@@ -15,6 +15,15 @@
 # becomes a `RangeJoin` over a co-partitioned index instead of the default
 # `SortMergeJoin` Spark would pick for ST_Intersects.
 #
+# Two Spark configs are overridden for the timed section and restored
+# afterward:
+#   spark.sql.autoBroadcastJoinThreshold = -1
+#     Prevents Spark from auto-broadcasting the small municipalities side,
+#     which would bypass Sedona's spatial partitioner and produce a
+#     BroadcastNestedLoopJoin (brute-force cross product).
+#   spark.sql.adaptive.enabled = false
+#     Prevents AQE from rewriting Sedona's RangeJoin plan before execution.
+#
 # Notes:
 # - stage_durations_ms is capped at the first 100 stages (dbutils.notebook.exit
 #   has a payload cap around 1 MB); a warning is logged if truncation happens.
@@ -31,6 +40,7 @@
 import json
 import time
 
+from pyspark.sql import functions as F
 from sedona.spark import SedonaContext
 
 # COMMAND ----------
@@ -82,9 +92,6 @@ print(f"Cluster parallelism: {parallelism}")
 print(f"Buildings partitions before repartition: {buildings_df.rdd.getNumPartitions()}")
 
 buildings_df = buildings_df.repartition(parallelism)
-
-buildings_df.createOrReplaceTempView("buildings")
-municipalities_df.createOrReplaceTempView("municipalities")
 
 # COMMAND ----------
 
@@ -145,28 +152,33 @@ municipalities_df.createOrReplaceTempView("municipalities")
 
 # COMMAND ----------
 
+_original_aqe = spark.conf.get("spark.sql.adaptive.enabled")
+_original_broadcast_threshold = spark.conf.get("spark.sql.autoBroadcastJoinThreshold")
+spark.conf.set("spark.sql.adaptive.enabled", "false")
+spark.conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+
 start_time = time.perf_counter()
 
-result = sedona.sql("""
-    SELECT
-        m.municipality_name,
-        COUNT(b.geometry) AS building_count
-    FROM municipalities m
-    JOIN buildings b
-      ON ST_Intersects(m.geometry, b.geometry)
-    GROUP BY m.municipality_name
-    ORDER BY building_count DESC
-""")
-
+result = (
+    municipalities_df.alias("m")
+    .join(
+        buildings_df.alias("b"),
+        F.expr("ST_Intersects(m.geometry, b.geometry)"),
+    )
+    .groupBy(F.col("m.municipality_name"))
+    .agg(F.count(F.col("b.geometry")).alias("building_count"))
+    .orderBy(F.desc("building_count"))
+)
 cardinality = result.count()
 elapsed_seconds = time.perf_counter() - start_time
+
+spark.conf.set("spark.sql.adaptive.enabled", _original_aqe)
+spark.conf.set("spark.sql.autoBroadcastJoinThreshold", _original_broadcast_threshold)
 
 print(f"Spatial join complete. Regions with matched buildings: {cardinality}")
 print(f"Elapsed seconds: {elapsed_seconds:.3f}")
 
 # COMMAND ----------
-
-from pyspark.sql import functions as F
 
 _STAGE_DURATION_CAP = 100
 


### PR DESCRIPTION
## Summary

- Disable Databricks Photon engine on cluster creation — Photon bypasses Sedona's custom Catalyst strategies (`JoinQueryDetector`), causing spatial joins to fall back to `BroadcastNestedLoopJoin` (brute-force cross product, single-threaded, 1.3h+ on small dataset)
- Add KryoSerializer to cluster spark_conf for correct Sedona geometry serialization
- Partitioned notebook: scope AQE and auto-broadcast threshold overrides around the timed join so Sedona's `RangeJoin` plan survives to execution
- Convert all three Databricks notebooks (broadcast, partitioned, default) from SQL API to DataFrame API for structural consistency
- Add per-iteration hard timeout to monitor — a single iteration exceeding `BENCHMARK_MAX_TIMED_WINDOW_SECONDS` (3600s) now stops the benchmark instead of running remaining iterations

## Verified

Physical plan confirmed via `result.explain(True)` on Databricks:
```
RangeJoin geometry#47: geometry, geometry#22: geometry, INTERSECTS
```
Previously showed `BroadcastNestedLoopJoin`.

Closes #327

## Test plan

- [x] Partitioned notebook produces `RangeJoin` in Spark UI DAG (verified on DBR 15.4, 4 workers, small dataset)
- [ ] Broadcast notebook still produces `BroadcastIndexJoin`
- [ ] Default notebook lets Spark/Sedona CBO pick the plan
- [ ] Per-iteration timeout triggers correctly when a single iteration exceeds 3600s