### PR TITLE
#331 Clean up orchestrator logging, add batch progress tracking

### DIFF
--- a/main.py
+++ b/main.py
@@ -385,12 +385,14 @@ def _stream_container_logs(container_group_name: str, lines_seen: int) -> int:
         return lines_seen
 
     lines = [line for line in output.splitlines() if line.strip()]
+    last_level = "info"
     for line in lines[lines_seen:]:
         parts = line.split(" - ", 2)
         if len(parts) == 3:
             level, message = parts[1].strip().lower(), parts[2]
+            last_level = level
         else:
-            level, message = "info", line
+            level, message = last_level, line
 
         if level not in ("warning", "error", "critical"):
             continue

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import random
 import shutil
 import string
 import subprocess
+import threading
 import time
 from datetime import date
 from concurrent.futures import ThreadPoolExecutor
@@ -63,10 +64,17 @@ def _run_benchmarks(
     completed_experiments: list[str] = []
     _clear_all_container_instances(experiments)
 
+    total_batches = _count_batches(experiments)
+    current_batch = 0
+    batch_durations: list[float] = []
+    suite_start = time.monotonic()
+
     for experiment in experiments:
         experiment_id = experiment["id"]
         if experiment_id in completed_experiments:
             continue
+
+        current_batch += 1
 
         related_experiment_ids = experiment["related_script_ids"]
         experiments_to_run: list[dict[str, int | str | list[str]]] = [experiment]
@@ -78,6 +86,18 @@ def _run_benchmarks(
 
             experiments_to_run.append(related_experiment)
 
+        batch_ids = [str(exp["id"]) for exp in experiments_to_run]
+        pct = (current_batch - 1) / total_batches * 100
+        eta = _estimate_eta(batch_durations, total_batches - current_batch + 1)
+        logger.info(
+            "[%s/%s] %s%% — Starting batch: %s%s",
+            current_batch, total_batches, f"{pct:.0f}", batch_ids, eta,
+        )
+
+        batch_start = time.monotonic()
+        batch_size = len(experiments_to_run)
+        batch_done = [0]
+        batch_lock = threading.Lock()
         failed_ids: list[str] = []
 
         def _safe_run(exp: dict[str, str | int | list[str]]) -> None:
@@ -91,9 +111,19 @@ def _run_benchmarks(
                     f"Experiment '{exp['id']}' failed at orchestrator level; "
                     f"continuing with remaining experiments. Error: {exc!r}"
                 )
+            finally:
+                with batch_lock:
+                    batch_done[0] += 1
+                    logger.info(
+                        "  [%s/%s in batch] '%s' done",
+                        batch_done[0], batch_size, exp["id"],
+                    )
 
         with ThreadPoolExecutor(max_workers=10) as pool:
             list(pool.map(_safe_run, experiments_to_run))
+
+        batch_elapsed = time.monotonic() - batch_start
+        batch_durations.append(batch_elapsed)
 
         if failed_ids:
             total = len(experiments_to_run)
@@ -115,8 +145,20 @@ def _run_benchmarks(
         for exp in experiments_to_run:
             completed_experiments.append(str(exp["id"]))
 
+        pct = current_batch / total_batches * 100
+        eta = _estimate_eta(batch_durations, total_batches - current_batch)
+        logger.info(
+            "[%s/%s] %s%% — Batch done in %s%s",
+            current_batch, total_batches, f"{pct:.0f}",
+            _format_duration(batch_elapsed), eta,
+        )
+
     _clear_all_container_instances(experiments)
-    logger.info(f"Completed benchmark run {benchmark_run}/{Config.BENCHMARK_RUNS}.")
+    total_elapsed = time.monotonic() - suite_start
+    logger.info(
+        f"Completed benchmark run {benchmark_run}/{Config.BENCHMARK_RUNS} "
+        f"in {_format_duration(total_elapsed)}."
+    )
 
 
 def _run_container_benchmark(
@@ -350,16 +392,23 @@ def _stream_container_logs(container_group_name: str, lines_seen: int) -> int:
         else:
             level, message = "info", line
 
-        log_fn = getattr(logger, level, logger.info)
+        if level not in ("warning", "error", "critical"):
+            continue
+
+        log_fn = getattr(logger, level, logger.warning)
         log_fn("[%s] %s", container_group_name, message)
 
     return len(lines)
 
 
 def _check_container_state(
-    container_group_name: str, poll_interval_seconds: float = 5
+    container_group_name: str,
+    poll_interval_seconds: float = 5,
+    heartbeat_interval_seconds: float = 300,
 ) -> None:
     lines_seen = 0
+    start = time.monotonic()
+    last_heartbeat = start
 
     while True:
         show_command = [
@@ -381,8 +430,9 @@ def _check_container_state(
             case "Succeeded":
                 time.sleep(5)
                 lines_seen = _stream_container_logs(container_group_name, lines_seen)
+                elapsed = time.monotonic() - start
                 logger.info(
-                    f"Container '{container_group_name}' | State: '{state}' | Benchmark run completed."
+                    f"Container '{container_group_name}' completed in {_format_duration(elapsed)}."
                 )
                 break
             case "Failed":
@@ -393,7 +443,45 @@ def _check_container_state(
                 raise RuntimeError(error_message)
             case _:
                 lines_seen = _stream_container_logs(container_group_name, lines_seen)
+                now = time.monotonic()
+                if now - last_heartbeat >= heartbeat_interval_seconds:
+                    elapsed = now - start
+                    logger.info(
+                        f"[{container_group_name}] Still running ({_format_duration(elapsed)} elapsed)"
+                    )
+                    last_heartbeat = now
                 time.sleep(poll_interval_seconds)
+
+
+def _count_batches(experiments: list[dict[str, str | int | list[str]]]) -> int:
+    seen: set[str] = set()
+    count = 0
+    for exp in experiments:
+        exp_id = str(exp["id"])
+        if exp_id in seen:
+            continue
+        count += 1
+        seen.add(exp_id)
+        for rid in exp.get("related_script_ids", []):
+            seen.add(str(rid))
+    return count
+
+
+def _format_duration(seconds: float) -> str:
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    minutes = seconds / 60
+    if minutes < 60:
+        return f"{minutes:.1f}min"
+    hours = minutes / 60
+    return f"{hours:.1f}h"
+
+
+def _estimate_eta(batch_durations: list[float], remaining: int) -> str:
+    if not batch_durations or remaining <= 0:
+        return ""
+    avg = sum(batch_durations) / len(batch_durations)
+    return f" — ETA: {_format_duration(avg * remaining)}"
 
 
 def _assert_related_ids_resolvable(

--- a/src/application/common/monitor_utils.py
+++ b/src/application/common/monitor_utils.py
@@ -122,7 +122,7 @@ def _save_run_cost_analytics(
     benchmark_run = _get_benchmark_run()
     if cost_configuration.include_aci:
         aci_cost = azure_cost_service.compute_aci_cost(query_id, start_time, end_time)
-        logger.debug(f"Computed ACI cost: {aci_cost.to_dict()}")
+        logger.debug("Computed ACI cost: %s", aci_cost.to_dict())
         monitoring_storage_service.write_cost_analytics_to_blob_storage(
             query_id=query_id,
             run_id=run_id,
@@ -140,7 +140,7 @@ def _save_run_cost_analytics(
         blob_cost = azure_cost_service.compute_blob_storage_cost(
             start_time, end_time, bytes_ingress, bytes_egress, operation_type
         )
-        logger.debug(f"Computed Blob Storage cost: {blob_cost.to_dict()}")
+        logger.debug("Computed Blob Storage cost: %s", blob_cost.to_dict())
         monitoring_storage_service.write_cost_analytics_to_blob_storage(
             query_id=query_id,
             run_id=run_id,
@@ -151,7 +151,7 @@ def _save_run_cost_analytics(
 
     if cost_configuration.include_postgres:
         postgres_cost = azure_cost_service.compute_database_cost(start_time, end_time)
-        logger.debug(f"Computed PostgreSQL cost: {postgres_cost.to_dict()}")
+        logger.debug("Computed PostgreSQL cost: %s", postgres_cost.to_dict())
         monitoring_storage_service.write_cost_analytics_to_blob_storage(
             query_id=query_id,
             run_id=run_id,
@@ -168,7 +168,7 @@ def _save_run_cost_analytics(
             num_workers=cost_configuration.num_workers,
             bytes_egress=egress,
         )
-        logger.debug(f"Computed Databricks cost: {databricks_cost.to_dict()}")
+        logger.debug("Computed Databricks cost: %s", databricks_cost.to_dict())
         monitoring_storage_service.write_cost_analytics_to_blob_storage(
             query_id=query_id,
             run_id=run_id,

--- a/src/application/common/monitor_utils.py
+++ b/src/application/common/monitor_utils.py
@@ -84,7 +84,7 @@ def _save_run_metadata(
         Containers.monitoring_storage_service
     ],
 ) -> None:
-    logger.info("Saving benchmark metadata to blob storage.")
+    logger.debug("Saving benchmark metadata to blob storage.")
     metadata_id = str(uuid.uuid4())
     timestamp = datetime.datetime.now(datetime.timezone.utc)
     monitoring_storage_service.write_metadata_to_blob_storage(
@@ -101,7 +101,7 @@ def _save_run_metadata(
         median_elapsed_seconds=median_elapsed_seconds,
     )
 
-    logger.info(f"Benchmark metadata saved with ID '{metadata_id}'.")
+    logger.debug(f"Benchmark metadata saved with ID '{metadata_id}'.")
 
 
 @inject
@@ -122,7 +122,7 @@ def _save_run_cost_analytics(
     benchmark_run = _get_benchmark_run()
     if cost_configuration.include_aci:
         aci_cost = azure_cost_service.compute_aci_cost(query_id, start_time, end_time)
-        logger.info(f"Computed ACI cost: {aci_cost.to_dict()}")
+        logger.debug(f"Computed ACI cost: {aci_cost.to_dict()}")
         monitoring_storage_service.write_cost_analytics_to_blob_storage(
             query_id=query_id,
             run_id=run_id,
@@ -140,7 +140,7 @@ def _save_run_cost_analytics(
         blob_cost = azure_cost_service.compute_blob_storage_cost(
             start_time, end_time, bytes_ingress, bytes_egress, operation_type
         )
-        logger.info(f"Computed Blob Storage cost: {blob_cost.to_dict()}")
+        logger.debug(f"Computed Blob Storage cost: {blob_cost.to_dict()}")
         monitoring_storage_service.write_cost_analytics_to_blob_storage(
             query_id=query_id,
             run_id=run_id,
@@ -151,7 +151,7 @@ def _save_run_cost_analytics(
 
     if cost_configuration.include_postgres:
         postgres_cost = azure_cost_service.compute_database_cost(start_time, end_time)
-        logger.info(f"Computed PostgreSQL cost: {postgres_cost.to_dict()}")
+        logger.debug(f"Computed PostgreSQL cost: {postgres_cost.to_dict()}")
         monitoring_storage_service.write_cost_analytics_to_blob_storage(
             query_id=query_id,
             run_id=run_id,
@@ -168,7 +168,7 @@ def _save_run_cost_analytics(
             num_workers=cost_configuration.num_workers,
             bytes_egress=egress,
         )
-        logger.info(f"Computed Databricks cost: {databricks_cost.to_dict()}")
+        logger.debug(f"Computed Databricks cost: {databricks_cost.to_dict()}")
         monitoring_storage_service.write_cost_analytics_to_blob_storage(
             query_id=query_id,
             run_id=run_id,

--- a/src/infra/infrastructure/services/blob_storage_service.py
+++ b/src/infra/infrastructure/services/blob_storage_service.py
@@ -49,7 +49,7 @@ class BlobStorageService(IBlobStorageService):
 
     def download_file(self, container_name: StorageContainer, blob_name: str) -> bytes | None:
         try:
-            logger.info(f"Downloading bytes from blob '{blob_name}' from container '{container_name.value}'.")
+            logger.debug(f"Downloading bytes from blob '{blob_name}' from container '{container_name.value}'.")
             container = self.get_container(container_name)
             blob_client = container.get_blob_client(blob_name)
             data = blob_client.download_blob().readall()

--- a/src/infra/infrastructure/services/databricks_service.py
+++ b/src/infra/infrastructure/services/databricks_service.py
@@ -233,6 +233,8 @@ class DatabricksService(IDatabricksService):
         logger.info(f"Requested library install on cluster {cluster_id}.")
 
     def _wait_for_cluster_running(self, cluster_id: str) -> None:
+        last_state = None
+        poll_start = time.monotonic()
         while True:
             try:
                 response = requests.get(
@@ -251,7 +253,10 @@ class DatabricksService(IDatabricksService):
                 continue
             data = response.json()
             state = data.get("state", "")
-            logger.info(f"Cluster {cluster_id}: state={state}")
+            if state != last_state:
+                elapsed = time.monotonic() - poll_start
+                logger.info(f"Cluster {cluster_id}: state={state} ({elapsed:.0f}s elapsed)")
+                last_state = state
             if state == DatabricksClusterState.RUNNING.value:
                 return
             if state in DatabricksClusterState.non_running_terminal_values():
@@ -268,6 +273,7 @@ class DatabricksService(IDatabricksService):
             time.sleep(Config.DATABRICKS_POLL_INTERVAL_SECONDS)
 
     def _wait_for_libraries_installed(self, cluster_id: str) -> None:
+        last_summary = None
         while True:
             try:
                 response = requests.get(
@@ -287,9 +293,11 @@ class DatabricksService(IDatabricksService):
             data = response.json()
             statuses = data.get("library_statuses", [])
             if not statuses:
-                logger.info(
-                    f"Cluster {cluster_id}: no library statuses reported yet. Waiting."
-                )
+                if last_summary is None:
+                    logger.info(
+                        f"Cluster {cluster_id}: no library statuses reported yet. Waiting."
+                    )
+                    last_summary = ""
                 time.sleep(Config.DATABRICKS_POLL_INTERVAL_SECONDS)
                 continue
 
@@ -297,7 +305,9 @@ class DatabricksService(IDatabricksService):
                 f"{self._library_label(s.get('library', {}))}={s.get('status', '')}"
                 for s in statuses
             )
-            logger.info(f"Cluster {cluster_id} library status: {summary}")
+            if summary != last_summary:
+                logger.info(f"Cluster {cluster_id} library status: {summary}")
+                last_summary = summary
 
             failed = [
                 s
@@ -419,6 +429,8 @@ class DatabricksService(IDatabricksService):
         required by /api/2.1/jobs/runs/get-output. Passing the parent run id to
         get-output returns 400 Bad Request.
         """
+        last_state_msg = None
+        poll_start = time.monotonic()
         while True:
             try:
                 response = requests.get(
@@ -444,7 +456,10 @@ class DatabricksService(IDatabricksService):
             state_msg = f"life_cycle_state={life_cycle_state}"
             if result_state:
                 state_msg += f", result_state={result_state}"
-            logger.info(f"Run {run_id}: {state_msg}")
+            if state_msg != last_state_msg:
+                elapsed = time.monotonic() - poll_start
+                logger.info(f"Run {run_id}: {state_msg} ({elapsed:.0f}s elapsed)")
+                last_state_msg = state_msg
 
             if life_cycle_state in DatabricksRunLifecycleState.terminal_values():
                 if result_state != DatabricksRunResultState.SUCCESS.value:


### PR DESCRIPTION
## Summary
- Suppress repeated Databricks poll logs — only log on state *change* with elapsed time (eliminates hundreds of identical `life_cycle_state=RUNNING` lines)
- Filter container log relay to WARNING+ only, add 5-minute heartbeat for long-running containers
- Add batch progress tracking: `[3/15] 20% — Starting batch: [...]` with ETA and per-container `[2/3 in batch]` completion
- Demote internal bookkeeping logs (metadata saves, cost computations, blob downloads) to DEBUG

## Test plan
- [ ] Verify syntax: `python -m py_compile` passes on all 4 modified files
- [ ] Run a local benchmark (`python benchmark_runner.py --script-id <id> ...`) and confirm Databricks poll logs only appear on state change
- [ ] Run full orchestrator (`python main.py`) and verify batch progress, ETA, heartbeats, and container relay filtering