### PR TITLE
#333 Remove stale CI services and update branch protection

### DIFF
--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -208,14 +208,8 @@ jobs:
           - service: national-scale-spatial-join-databricks-default-2-nodes
             display_name: Sedona National Scale Spatial Join - Default - 2 Nodes
 
-          - service: national-scale-spatial-join-databricks-default-4-nodes
-            display_name: Sedona National Scale Spatial Join - Default - 4 Nodes
-
           - service: national-scale-spatial-join-databricks-default-8-nodes
             display_name: Sedona National Scale Spatial Join - Default - 8 Nodes
-
-          - service: national-scale-spatial-join-databricks-default-12-nodes
-            display_name: Sedona National Scale Spatial Join - Default - 12 Nodes
 
           - service: national-scale-spatial-join-databricks-default-16-nodes
             display_name: Sedona National Scale Spatial Join - Default - 16 Nodes

--- a/.github/workflows/push-containers-to-acr.yml
+++ b/.github/workflows/push-containers-to-acr.yml
@@ -149,17 +149,9 @@ jobs:
             image: national-scale-spatial-join-databricks-default-2-nodes
             display_name: Sedona National Scale Spatial Join - Default - 2 Nodes
 
-          - service: national-scale-spatial-join-databricks-default-4-nodes
-            image: national-scale-spatial-join-databricks-default-4-nodes
-            display_name: Sedona National Scale Spatial Join - Default - 4 Nodes
-
           - service: national-scale-spatial-join-databricks-default-8-nodes
             image: national-scale-spatial-join-databricks-default-8-nodes
             display_name: Sedona National Scale Spatial Join - Default - 8 Nodes
-
-          - service: national-scale-spatial-join-databricks-default-12-nodes
-            image: national-scale-spatial-join-databricks-default-12-nodes
-            display_name: Sedona National Scale Spatial Join - Default - 12 Nodes
 
           - service: national-scale-spatial-join-databricks-default-16-nodes
             image: national-scale-spatial-join-databricks-default-16-nodes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,15 +227,6 @@ services:
     image: national-scale-spatial-join-databricks-default-2-nodes:latest
     command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-default-2-nodes --benchmark-run 1 --run-id ABCDEF
 
-  national-scale-spatial-join-databricks-default-4-nodes:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: national-scale-spatial-join-databricks-default-4-nodes:latest
-    command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-default-4-nodes --benchmark-run 1 --run-id ABCDEF
-
   national-scale-spatial-join-databricks-default-8-nodes:
     env_file:
       - .env
@@ -244,15 +235,6 @@ services:
       dockerfile: .docker/Query.Dockerfile
     image: national-scale-spatial-join-databricks-default-8-nodes:latest
     command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-default-8-nodes --benchmark-run 1 --run-id ABCDEF
-
-  national-scale-spatial-join-databricks-default-12-nodes:
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: .docker/Query.Dockerfile
-    image: national-scale-spatial-join-databricks-default-12-nodes:latest
-    command: python benchmark_runner.py --script-id national-scale-spatial-join-databricks-default-12-nodes --benchmark-run 1 --run-id ABCDEF
 
   national-scale-spatial-join-databricks-default-16-nodes:
     env_file:


### PR DESCRIPTION
## Summary
- Remove `national-scale-spatial-join-databricks-default-4-nodes` and `default-12-nodes` from CI workflows and docker-compose (pruned in #309 but left behind)
- Branch ruleset updated via API to require all 28 current CI jobs (was 7)

## Test plan
- [ ] Verify CI matrix matches `benchmarks.yml` images exactly
- [ ] Confirm branch ruleset at https://github.com/kartAI/doppa/rules/8545088 shows 28 required checks