### PR TITLE
#337 Increase spark.driver.maxResultSize for broadcast joins

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -139,6 +139,7 @@ class Config:
     DATABRICKS_HTTP_TIMEOUT_SECONDS: int = 30
     DATABRICKS_DRIVER_MEMORY: str = "9g"
     DATABRICKS_DRIVER_MEMORY_OVERHEAD: str = "512m"
+    DATABRICKS_DRIVER_MAX_RESULT_SIZE: str = "8g"
     DATABRICKS_SEDONA_MAVEN_COORDINATES: str = (
         "org.apache.sedona:sedona-spark-shaded-3.5_2.12:1.7.1"
     )

--- a/src/infra/infrastructure/services/databricks_service.py
+++ b/src/infra/infrastructure/services/databricks_service.py
@@ -150,6 +150,7 @@ class DatabricksService(IDatabricksService):
             "spark_conf": {
                 "spark.driver.memory": Config.DATABRICKS_DRIVER_MEMORY,
                 "spark.driver.memoryOverhead": Config.DATABRICKS_DRIVER_MEMORY_OVERHEAD,
+                "spark.driver.maxResultSize": Config.DATABRICKS_DRIVER_MAX_RESULT_SIZE,
                 f"spark.hadoop.fs.azure.account.auth.type.{Config.AZURE_BLOB_STORAGE_ACCOUNT_NAME}.dfs.core.windows.net": "SharedKey",
                 f"spark.hadoop.fs.azure.account.key.{Config.AZURE_BLOB_STORAGE_ACCOUNT_NAME}.dfs.core.windows.net": Config.AZURE_BLOB_STORAGE_ACCOUNT_KEY,
                 # Photon bypasses Sedona's custom Catalyst strategies


### PR DESCRIPTION
## Summary
- Add `DATABRICKS_DRIVER_MAX_RESULT_SIZE = "8g"` to `Config` and wire it into the cluster `spark_conf`
- Fixes broadcast spatial join failing with `spark.driver.maxResultSize` exceeded on national-scale data (~100M buildings × 357 municipalities)
- 8g gives 2× headroom over the observed 4.0 GiB serialized result size at LARGE dataset tier

Closes #337