### PR TITLE
#346 Disable AQE in broadcast notebook

### DIFF
--- a/src/presentation/databricks/national_scale_spatial_join_broadcast.py
+++ b/src/presentation/databricks/national_scale_spatial_join_broadcast.py
@@ -14,6 +14,10 @@
 # `broadcast()` so Sedona picks `BroadcastIndexJoin` instead of the default
 # `SortMergeJoin` Spark would pick for ST_Intersects.
 #
+# AQE (Adaptive Query Execution) is disabled before the timed section to
+# prevent it from rewriting Sedona's BroadcastIndexJoin plan back into
+# Spark's native BroadcastNestedLoopJoin (a brute-force cross product).
+#
 # Notes:
 # - stage_durations_ms is capped at the first 100 stages (dbutils.notebook.exit
 #   has a payload cap around 1 MB); a warning is logged if truncation happens.
@@ -139,6 +143,9 @@ buildings_df = buildings_df.repartition(parallelism)
 
 # COMMAND ----------
 
+_original_aqe = spark.conf.get("spark.sql.adaptive.enabled")
+spark.conf.set("spark.sql.adaptive.enabled", "false")
+
 start_time = time.perf_counter()
 
 result = (
@@ -154,6 +161,8 @@ result = (
 
 cardinality = result.count()
 elapsed_seconds = time.perf_counter() - start_time
+
+spark.conf.set("spark.sql.adaptive.enabled", _original_aqe)
 
 print(f"Spatial join complete. Regions with matched buildings: {cardinality}")
 print(f"Elapsed seconds: {elapsed_seconds:.3f}")


### PR DESCRIPTION
## Summary
- Disable Adaptive Query Execution (AQE) around the timed spatial join in the broadcast notebook
- AQE was rewriting Sedona's `BroadcastIndexJoinExec` into Spark's native `BroadcastNestedLoopJoinExec` (brute-force cross product), causing `spark.driver.maxResultSize` overflow at national scale
- Mirrors the same AQE guard already present in the partitioned notebook

Closes #346

## Test plan
- [ ] Run broadcast notebook on Databricks at national scale and verify join completes without `maxResultSize` error
- [ ] Confirm Sedona selects `BroadcastIndexJoin` (check Spark UI physical plan)