### PR TITLE
#346 Fix Databricks spatial join: collect() instead of count()

### DIFF
--- a/benchmark_runner.py
+++ b/benchmark_runner.py
@@ -1,6 +1,12 @@
 import argparse
 from typing import Optional
-from src.domain.enums import DatasetSize
+
+import yaml
+
+from src import Config
+from src.application.common import logger
+from src.application.common.monitor_utils import _save_run_metadata
+from src.domain.enums import DatasetSize, StopReason
 from src.presentation.configuration import initialize_dependencies
 from src.presentation.entrypoints import (
     setup_benchmarking_framework,
@@ -38,6 +44,21 @@ def benchmark_runner() -> None:
     initialize_dependencies(
         run_id=run_id, benchmark_run=benchmark_run, dataset_size=dataset_size
     )
+
+    if _is_skipped(script_id):
+        logger.info(f"Experiment '{script_id}' marked skip=true in benchmarks.yml. Recording as skipped.")
+        _save_run_metadata(
+            query_id=script_id,
+            run_id=run_id,
+            achieved_iterations=0,
+            failed_iterations=0,
+            stop_reason=StopReason.FAILED,
+            ci_half_width_seconds=None,
+            ci_half_width_relative=None,
+            mean_elapsed_seconds=None,
+            median_elapsed_seconds=None,
+        )
+        return
 
     match _strip_dataset_size_suffix(script_id):
         case "bbox-filtering-duckdb":
@@ -116,6 +137,15 @@ def _strip_dataset_size_suffix(script_id: str) -> str:
         if script_id.endswith(suffix):
             return script_id[: -len(suffix)]
     return script_id
+
+
+def _is_skipped(script_id: str) -> bool:
+    with open(Config.BENCHMARK_FILE) as f:
+        cfg = yaml.safe_load(f)
+    for exp in cfg.get("experiments", []):
+        if exp.get("id") == script_id and exp.get("skip"):
+            return True
+    return False
 
 
 def _get_args() -> tuple[str, int, Optional[str], DatasetSize]:

--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -203,6 +203,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    skip: true  # OOM on Azure PostgreSQL Flex Server at large scale
     related_script_ids:
       - national-scale-spatial-join-duckdb-large
 
@@ -292,6 +293,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: medium
+    skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at medium scale
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-2-nodes-medium
 
@@ -300,6 +302,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-4-nodes-large
       - national-scale-spatial-join-databricks-partitioned-16-nodes-large
@@ -317,6 +320,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: medium
+    skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at medium scale
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-4-nodes-medium
 
@@ -325,6 +329,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-2-nodes-large
       - national-scale-spatial-join-databricks-partitioned-16-nodes-large
@@ -344,6 +349,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: medium
+    skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at medium scale
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-8-nodes-medium
       - national-scale-spatial-join-duckdb-medium
@@ -354,6 +360,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-8-nodes-large
 
@@ -362,6 +369,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-2-nodes-large
       - national-scale-spatial-join-databricks-partitioned-4-nodes-large

--- a/src/infra/infrastructure/services/databricks_service.py
+++ b/src/infra/infrastructure/services/databricks_service.py
@@ -156,6 +156,14 @@ class DatabricksService(IDatabricksService):
                 # the classic Spark planner respects.
                 "spark.databricks.photon.enabled": "false",
                 "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
+                # AQE can rewrite Sedona's spatial join plans (RangeJoin,
+                # BroadcastIndexJoin) back into BroadcastNestedLoopJoin at
+                # execution time, even when the static plan is correct.
+                # Setting at cluster level ensures it's active before any
+                # notebook code runs — notebook-level spark.conf.set() may
+                # not take effect for job submissions on DBR 15.x.
+                "spark.sql.adaptive.enabled": "false",
+                "spark.sql.autoBroadcastJoinThreshold": "-1",
             },
         }
         response = requests.post(

--- a/src/presentation/databricks/national_scale_spatial_join_broadcast.py
+++ b/src/presentation/databricks/national_scale_spatial_join_broadcast.py
@@ -159,7 +159,8 @@ result = (
     .orderBy(F.desc("building_count"))
 )
 
-cardinality = result.count()
+collected = result.collect()
+cardinality = len(collected)
 elapsed_seconds = time.perf_counter() - start_time
 
 spark.conf.set("spark.sql.adaptive.enabled", _original_aqe)

--- a/src/presentation/databricks/national_scale_spatial_join_partitioned.py
+++ b/src/presentation/databricks/national_scale_spatial_join_partitioned.py
@@ -170,7 +170,8 @@ try:
         .agg(F.count(F.col("b.geometry")).alias("building_count"))
         .orderBy(F.desc("building_count"))
     )
-    cardinality = result.count()
+    collected = result.collect()
+    cardinality = len(collected)
     elapsed_seconds = time.perf_counter() - start_time
 
     print(f"Spatial join complete. Regions with matched buildings: {cardinality}")


### PR DESCRIPTION
This pull request introduces improvements to the benchmark runner, configuration, and Databricks job execution to better handle out-of-memory (OOM) scenarios and ensure accurate experiment tracking. The main changes include adding the ability to skip problematic experiments, updating cluster and job settings to avoid Spark query plan rewrites, and fixing result collection in Databricks scripts.

**Benchmark skipping and experiment tracking:**
- `benchmark_runner.py`, `benchmarks.yml`: Added a `skip` flag to experiments in `benchmarks.yml` and logic in `benchmark_runner.py` to detect and record skipped experiments, preventing OOM-prone benchmarks from running and ensuring metadata is saved with a `FAILED` stop reason. [[1]](diffhunk://#diff-56f497f357c1a86b3152b78bc93c915029e06e2021f9a1b2ca20caf80a1823d8L3-R9) [[2]](diffhunk://#diff-56f497f357c1a86b3152b78bc93c915029e06e2021f9a1b2ca20caf80a1823d8R48-R62) [[3]](diffhunk://#diff-56f497f357c1a86b3152b78bc93c915029e06e2021f9a1b2ca20caf80a1823d8R142-R150) [[4]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R206) [[5]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R296) [[6]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R305) [[7]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R323) [[8]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R332) [[9]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R352) [[10]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R363) [[11]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R372)

**Databricks cluster and Spark settings:**
- [`src/infra/infrastructure/services/databricks_service.py`](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11R159-R166): Disabled Spark Adaptive Query Execution (AQE) and automatic broadcast join threshold at the cluster level to prevent runtime query plan rewrites that could cause instability in spatial join jobs.

**Databricks result collection fix:**
- `src/presentation/databricks/national_scale_spatial_join_broadcast.py`, `src/presentation/databricks/national_scale_spatial_join_partitioned.py`: Changed from using `result.count()` to collecting results and using `len(collected)` to ensure accurate cardinality measurement and avoid possible Spark execution issues. [[1]](diffhunk://#diff-d1565e8d515006d231a182a17666dfb6cf61a534cbd51c89ca6f7bbc9d0b0efeL162-R163) [[2]](diffhunk://#diff-0e61b407a4a48bcea74680800c1fbc2c4e604ad9e771fc493dc07ad02f4cd57cL173-R174)