### PR TITLE
Feature/348 increase benchmark runs and fix fixed iteration ceiling

### DIFF
--- a/benchmark_runner.py
+++ b/benchmark_runner.py
@@ -45,14 +45,15 @@ def benchmark_runner() -> None:
         run_id=run_id, benchmark_run=benchmark_run, dataset_size=dataset_size
     )
 
-    if _is_skipped(script_id):
-        logger.info(f"Experiment '{script_id}' marked skip=true in benchmarks.yml. Recording as skipped.")
+    skip_reason = _get_skip_reason(script_id)
+    if skip_reason is not None:
+        logger.info(f"Experiment '{script_id}' skipped in benchmarks.yml (reason={skip_reason.value}).")
         _save_run_metadata(
             query_id=script_id,
             run_id=run_id,
             achieved_iterations=0,
             failed_iterations=0,
-            stop_reason=StopReason.FAILED,
+            stop_reason=skip_reason,
             ci_half_width_seconds=None,
             ci_half_width_relative=None,
             mean_elapsed_seconds=None,
@@ -139,13 +140,13 @@ def _strip_dataset_size_suffix(script_id: str) -> str:
     return script_id
 
 
-def _is_skipped(script_id: str) -> bool:
+def _get_skip_reason(script_id: str) -> StopReason | None:
     with open(Config.BENCHMARK_FILE) as f:
         cfg = yaml.safe_load(f)
     for exp in cfg.get("experiments", []):
         if exp.get("id") == script_id and exp.get("skip"):
-            return True
-    return False
+            return StopReason.from_skip(exp["skip"])
+    return None
 
 
 def _get_args() -> tuple[str, int, Optional[str], DatasetSize]:

--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -16,6 +16,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: small
+    runs: 30
     related_script_ids:
       - point-in-polygon-lookup-postgis-small
       - point-in-polygon-lookup-local-small
@@ -25,6 +26,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: small
+    runs: 30
     related_script_ids:
       - point-in-polygon-lookup-duckdb-small
       - point-in-polygon-lookup-local-small
@@ -34,6 +36,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: small
+    runs: 30
     related_script_ids:
       - point-in-polygon-lookup-duckdb-small
       - point-in-polygon-lookup-postgis-small
@@ -43,6 +46,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 30
     related_script_ids:
       - point-in-polygon-lookup-postgis-large
 
@@ -51,6 +55,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 30
     related_script_ids:
       - point-in-polygon-lookup-duckdb-large
 
@@ -60,6 +65,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: small
+    runs: 30
     related_script_ids:
       - knn-search-postgis-small
       - knn-search-local-small
@@ -69,6 +75,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: small
+    runs: 30
     related_script_ids:
       - knn-search-duckdb-small
       - knn-search-local-small
@@ -78,6 +85,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: small
+    runs: 30
     related_script_ids:
       - knn-search-duckdb-small
       - knn-search-postgis-small
@@ -87,6 +95,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 30
     related_script_ids:
       - knn-search-postgis-large
 
@@ -95,6 +104,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 30
     related_script_ids:
       - knn-search-duckdb-large
 
@@ -104,6 +114,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: small
+    runs: 30
     related_script_ids:
       - bbox-filtering-postgis-small
       - bbox-filtering-local-small
@@ -113,6 +124,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: small
+    runs: 30
     related_script_ids:
       - bbox-filtering-duckdb-small
       - bbox-filtering-local-small
@@ -122,6 +134,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: small
+    runs: 30
     related_script_ids:
       - bbox-filtering-duckdb-small
       - bbox-filtering-postgis-small
@@ -131,6 +144,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 30
     related_script_ids:
       - bbox-filtering-postgis-large
 
@@ -139,6 +153,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 30
     related_script_ids:
       - bbox-filtering-duckdb-large
 
@@ -155,6 +170,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: small
+    runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-8-nodes-small
       - national-scale-spatial-join-databricks-partitioned-8-nodes-small
@@ -165,6 +181,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: small
+    runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-8-nodes-small
       - national-scale-spatial-join-databricks-partitioned-8-nodes-small
@@ -175,6 +192,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: medium
+    runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-8-nodes-medium
       - national-scale-spatial-join-databricks-partitioned-8-nodes-medium
@@ -185,6 +203,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: medium
+    runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-8-nodes-medium
       - national-scale-spatial-join-databricks-partitioned-8-nodes-medium
@@ -195,6 +214,8 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 3
+    skip: true  # exceeds 60-min per-iteration threshold; existing data from run 2026-05-24-HBJYYT sufficient
     related_script_ids:
       - national-scale-spatial-join-postgis-large
 
@@ -203,6 +224,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 3
     skip: true  # OOM on Azure PostgreSQL Flex Server at large scale
     related_script_ids:
       - national-scale-spatial-join-duckdb-large
@@ -213,6 +235,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: medium
+    runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-2-nodes-medium
 
@@ -221,6 +244,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-4-nodes-large
       - national-scale-spatial-join-databricks-broadcast-16-nodes-large
@@ -230,6 +254,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: small
+    runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-4-nodes-small
 
@@ -238,6 +263,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: medium
+    runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-4-nodes-medium
 
@@ -246,6 +272,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-2-nodes-large
       - national-scale-spatial-join-databricks-broadcast-16-nodes-large
@@ -255,6 +282,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: small
+    runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-8-nodes-small
       - national-scale-spatial-join-duckdb-small
@@ -265,6 +293,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: medium
+    runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-8-nodes-medium
       - national-scale-spatial-join-duckdb-medium
@@ -275,6 +304,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-8-nodes-large
 
@@ -283,6 +313,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-2-nodes-large
       - national-scale-spatial-join-databricks-broadcast-4-nodes-large
@@ -293,6 +324,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: medium
+    runs: 3
     skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at medium scale
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-2-nodes-medium
@@ -302,6 +334,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 3
     skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-4-nodes-large
@@ -312,6 +345,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: small
+    runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-4-nodes-small
 
@@ -320,6 +354,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: medium
+    runs: 3
     skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at medium scale
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-4-nodes-medium
@@ -329,6 +364,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 3
     skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-2-nodes-large
@@ -339,6 +375,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: small
+    runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-8-nodes-small
       - national-scale-spatial-join-duckdb-small
@@ -349,6 +386,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: medium
+    runs: 3
     skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at medium scale
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-8-nodes-medium
@@ -360,6 +398,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 3
     skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-8-nodes-large
@@ -369,6 +408,7 @@ experiments:
     cpu: 4
     memory_gb: 16
     dataset_size: large
+    runs: 3
     skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-2-nodes-large

--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -215,7 +215,7 @@ experiments:
     memory_gb: 16
     dataset_size: large
     runs: 3
-    skip: true  # exceeds 60-min per-iteration threshold; existing data from run 2026-05-24-HBJYYT sufficient
+    skip: timeout  # exceeds 60-min per-iteration threshold; existing data from run 2026-05-24-HBJYYT sufficient
     related_script_ids:
       - national-scale-spatial-join-postgis-large
 
@@ -225,7 +225,7 @@ experiments:
     memory_gb: 16
     dataset_size: large
     runs: 3
-    skip: true  # OOM on Azure PostgreSQL Flex Server at large scale
+    skip: failed  # OOM on Azure PostgreSQL Flex Server at large scale
     related_script_ids:
       - national-scale-spatial-join-duckdb-large
 
@@ -325,7 +325,7 @@ experiments:
     memory_gb: 16
     dataset_size: medium
     runs: 3
-    skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at medium scale
+    skip: failed  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at medium scale
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-2-nodes-medium
 
@@ -335,7 +335,7 @@ experiments:
     memory_gb: 16
     dataset_size: large
     runs: 3
-    skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
+    skip: failed  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-4-nodes-large
       - national-scale-spatial-join-databricks-partitioned-16-nodes-large
@@ -355,7 +355,7 @@ experiments:
     memory_gb: 16
     dataset_size: medium
     runs: 3
-    skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at medium scale
+    skip: failed  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at medium scale
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-4-nodes-medium
 
@@ -365,7 +365,7 @@ experiments:
     memory_gb: 16
     dataset_size: large
     runs: 3
-    skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
+    skip: failed  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-2-nodes-large
       - national-scale-spatial-join-databricks-partitioned-16-nodes-large
@@ -387,7 +387,7 @@ experiments:
     memory_gb: 16
     dataset_size: medium
     runs: 3
-    skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at medium scale
+    skip: failed  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at medium scale
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-8-nodes-medium
       - national-scale-spatial-join-duckdb-medium
@@ -399,7 +399,7 @@ experiments:
     memory_gb: 16
     dataset_size: large
     runs: 3
-    skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
+    skip: failed  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-8-nodes-large
 
@@ -409,7 +409,7 @@ experiments:
     memory_gb: 16
     dataset_size: large
     runs: 3
-    skip: true  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
+    skip: failed  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-2-nodes-large
       - national-scale-spatial-join-databricks-partitioned-4-nodes-large

--- a/main.py
+++ b/main.py
@@ -74,6 +74,17 @@ def _run_benchmarks(
         if experiment_id in completed_experiments:
             continue
 
+        experiment_runs = experiment.get("runs", Config.BENCHMARK_RUNS)
+        if benchmark_run > experiment_runs:
+            completed_experiments.append(experiment_id)
+            for rid in experiment.get("related_script_ids", []):
+                completed_experiments.append(str(rid))
+            logger.info(
+                "Skipping '%s' — benchmark run %s exceeds experiment runs limit %s.",
+                experiment_id, benchmark_run, experiment_runs,
+            )
+            continue
+
         current_batch += 1
 
         related_experiment_ids = experiment["related_script_ids"]

--- a/src/config.py
+++ b/src/config.py
@@ -53,7 +53,7 @@ class Config:
     MVT_TILES_PATH: Path = ROOT_DIR / "resources" / "tiles.json"
 
     # LOGGING
-    LOGGING_LEVEL: int = logging.INFO
+    LOGGING_LEVEL: int = logging.DEBUG
     LOG_FILE: Path = LOG_DIR / f"{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
 
     # GEONORGE
@@ -88,7 +88,9 @@ class Config:
 
     # TEST MODE
     SETUP_COUNTY_LIMIT: int | None = (
-        int(os.getenv("SETUP_COUNTY_LIMIT")) if os.getenv("SETUP_COUNTY_LIMIT") else None
+        int(os.getenv("SETUP_COUNTY_LIMIT"))
+        if os.getenv("SETUP_COUNTY_LIMIT")
+        else None
     )
 
     # BENCHMARKING

--- a/src/config.py
+++ b/src/config.py
@@ -95,7 +95,7 @@ class Config:
     BENCHMARK_FILE: Path = ROOT_DIR / "benchmarks.yml"
     RUN_ID_LENGTH: int = 6
     DEFAULT_SAMPLE_TIMEOUT: float = 0.01
-    BENCHMARK_RUNS: int = 1
+    BENCHMARK_RUNS: int = 30
     BENCHMARK_WARMUP_ITERATIONS: int = 5
     BENCHMARK_ITERATIONS: int = 100
     BENCHMARK_METADATA_BLOB_NAME: str = "benchmark_metadata.parquet"
@@ -104,15 +104,15 @@ class Config:
     # Sequential stopping rule (bootstrapped CI on mean elapsed time)
     BENCHMARK_MIN_ITERATIONS: int = 10
     BENCHMARK_MIN_TIMED_WINDOW_SECONDS: int = 60
-    BENCHMARK_MAX_ITERATION_SECONDS: int = 4500
+    BENCHMARK_MAX_ITERATION_SECONDS: int = 3600
     BENCHMARK_MAX_TIMED_WINDOW_SECONDS: int = 6 * BENCHMARK_MAX_ITERATION_SECONDS
     BENCHMARK_TARGET_CI_HALF_WIDTH_RELATIVE: float = 0.05
     BENCHMARK_BOOTSTRAP_RESAMPLES: int = 1000
     BENCHMARK_CI_CONFIDENCE: float = 0.95
     BENCHMARK_MAX_CONSECUTIVE_FAILURES: int = 3
 
-    # Fixed-iteration cumulative wall-clock ceiling (75 min)
-    BENCHMARK_MAX_FIXED_WINDOW_SECONDS: int = 75 * 60
+    # Fixed-iteration cumulative wall-clock ceiling (300 min)
+    BENCHMARK_MAX_FIXED_WINDOW_SECONDS: int = 5 * BENCHMARK_MAX_ITERATION_SECONDS
 
     INGESTION_DELAY_SECONDS: int = 600
 

--- a/src/config.py
+++ b/src/config.py
@@ -53,7 +53,7 @@ class Config:
     MVT_TILES_PATH: Path = ROOT_DIR / "resources" / "tiles.json"
 
     # LOGGING
-    LOGGING_LEVEL: int = logging.DEBUG
+    LOGGING_LEVEL: int = logging.INFO
     LOG_FILE: Path = LOG_DIR / f"{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
 
     # GEONORGE

--- a/src/domain/enums/stop_reason.py
+++ b/src/domain/enums/stop_reason.py
@@ -8,3 +8,9 @@ class StopReason(Enum):
     FIXED = "fixed"
     PARTIAL = "partial"
     FAILED = "failed"
+
+    @classmethod
+    def from_skip(cls, value) -> "StopReason":
+        if isinstance(value, str):
+            return cls(value)
+        return cls.FAILED


### PR DESCRIPTION
This pull request updates the benchmark configuration and runner to improve experiment tracking and handling of skipped benchmarks. The most significant changes are the addition of an explicit `runs` parameter for all experiments in `benchmarks.yml`, and an enhancement to how skipped experiments and their reasons are recorded and reported in `benchmark_runner.py`.

**Benchmark configuration improvements:**

* Added a `runs` parameter to every experiment in `benchmarks.yml`, specifying the number of times each benchmark should be executed (typically set to 30 for smaller experiments and 3 for larger or resource-intensive ones). [[1]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R19) [[2]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R29) [[3]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R39) [[4]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R49) [[5]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R58) [[6]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R68) [[7]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R78) [[8]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R88) [[9]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R98) [[10]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R107) [[11]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R117) [[12]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R127) [[13]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R137) [[14]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R147) [[15]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R156) [[16]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R173) [[17]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R184) [[18]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R195) [[19]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R206) [[20]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R217-R218) [[21]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L206-R228) [[22]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R238) [[23]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R247) [[24]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R257) [[25]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R266) [[26]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R275) [[27]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R285) [[28]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R296) [[29]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R307) [[30]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R316) [[31]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L296-R328) [[32]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L305-R338) [[33]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R348) [[34]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L323-R358) [[35]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L332-R368) [[36]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R378) [[37]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L352-R390) [[38]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L363-R402)

* Updated the `skip` field for certain experiments to specify more descriptive reasons (e.g., `timeout`, `failed`), replacing simple boolean values. This provides clearer context for why experiments are skipped, such as exceeding time limits or encountering out-of-memory errors. [[1]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5R217-R218) [[2]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L206-R228) [[3]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L296-R328) [[4]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L305-R338) [[5]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L323-R358) [[6]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L332-R368) [[7]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L352-R390) [[8]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L363-R402)

**Benchmark runner enhancements:**

* Refactored the skip logic in `benchmark_runner.py` to use a new `_get_skip_reason()` function, which returns a `StopReason` enum value (or `None`) instead of a boolean. This enables more detailed reporting and handling of different skip scenarios.

* Updated the main experiment runner to log and record the specific skip reason in the metadata when an experiment is skipped, rather than just marking it as failed.