### PR TITLE
#351 Fix env var validation, batch structure, and README inaccuracies

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ collected so far). The loop stops as soon as all of these hold:
 The per-query value in `BenchmarkIteration` (for example `POINT_IN_POLYGON_LOOKUP=2500`, `KNN_SEARCH=4000`) acts as
 an **upper bound** on iterations. If iterations hit the ceiling but the 60-second window floor has not yet been met,
 the loop continues past the ceiling and logs a one-time warning, so the cost-metric window stays valid. A separate
-hard cap `Config.BENCHMARK_MAX_TIMED_WINDOW_SECONDS=5400` (90 minutes) protects against runaway runs and trips
+hard cap `Config.BENCHMARK_MAX_TIMED_WINDOW_SECONDS=21600` (6 hours) protects against runaway runs and trips
 `stop_reason="timeout"` if it fires. The bootstrap RNG is seeded deterministically from `(run_id, query_id)`
 (`blake2b` digest in `_make_bootstrap_rng`), so identical reruns reproduce the same stopping point.
 
@@ -170,7 +170,7 @@ to the elapsed-time distribution.
 | PMTiles                 | Cloud-native vector tiles        | PMTiles archive in blob storage, accessed via HTTP range reads                         |
 | WMS-style vector tiles  | Traditional vector tiles         | `doppa-vmt` web app for containers, tiles assembled on demand                          |
 
-DuckDB and PostGIS each run inside an Azure Container Instance with 3 vCPU and 8 GB RAM, so CPU and memory baselines
+DuckDB and PostGIS each run inside an Azure Container Instance with 4 vCPU and 16 GB RAM, so CPU and memory baselines
 match between the single-node engines.
 
 ### Databricks cluster lifecycle

--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -246,7 +246,6 @@ experiments:
     dataset_size: large
     runs: 3
     related_script_ids:
-      - national-scale-spatial-join-databricks-broadcast-4-nodes-large
       - national-scale-spatial-join-databricks-broadcast-16-nodes-large
 
   - id: national-scale-spatial-join-databricks-broadcast-4-nodes-small
@@ -273,9 +272,7 @@ experiments:
     memory_gb: 16
     dataset_size: large
     runs: 3
-    related_script_ids:
-      - national-scale-spatial-join-databricks-broadcast-2-nodes-large
-      - national-scale-spatial-join-databricks-broadcast-16-nodes-large
+    related_script_ids: []
 
   - id: national-scale-spatial-join-databricks-broadcast-8-nodes-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-broadcast-8-nodes:latest
@@ -316,7 +313,6 @@ experiments:
     runs: 3
     related_script_ids:
       - national-scale-spatial-join-databricks-broadcast-2-nodes-large
-      - national-scale-spatial-join-databricks-broadcast-4-nodes-large
 
   # ---- Sedona partitioned strategy ----
   - id: national-scale-spatial-join-databricks-partitioned-2-nodes-medium
@@ -337,7 +333,6 @@ experiments:
     runs: 3
     skip: failed  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
     related_script_ids:
-      - national-scale-spatial-join-databricks-partitioned-4-nodes-large
       - national-scale-spatial-join-databricks-partitioned-16-nodes-large
 
   - id: national-scale-spatial-join-databricks-partitioned-4-nodes-small
@@ -366,9 +361,7 @@ experiments:
     dataset_size: large
     runs: 3
     skip: failed  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
-    related_script_ids:
-      - national-scale-spatial-join-databricks-partitioned-2-nodes-large
-      - national-scale-spatial-join-databricks-partitioned-16-nodes-large
+    related_script_ids: []
 
   - id: national-scale-spatial-join-databricks-partitioned-8-nodes-small
     image: doppaacr.azurecr.io/national-scale-spatial-join-databricks-partitioned-8-nodes:latest
@@ -412,5 +405,4 @@ experiments:
     skip: failed  # executor OOM: RangeJoin spatial index exceeds Standard_D4s_v3 memory at large scale
     related_script_ids:
       - national-scale-spatial-join-databricks-partitioned-2-nodes-large
-      - national-scale-spatial-join-databricks-partitioned-4-nodes-large
 

--- a/src/config.py
+++ b/src/config.py
@@ -9,6 +9,13 @@ from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())
 
 
+def _require_env(name: str) -> str:
+    value = os.getenv(name)
+    if value is None:
+        raise EnvironmentError(f"Required environment variable '{name}' is not set")
+    return value
+
+
 @dataclass(frozen=True)
 class Config:
     IS_NOTEBOOK: bool = False
@@ -17,12 +24,12 @@ class Config:
     # AZURE
     AZURE_RESOURCE_GROUP: str = "doppa"
     AZURE_RESOURCE_LOCATION: str = "norwayeast"
-    AZURE_SUBSCRIPTION_ID: str = os.getenv("AZURE_SUBSCRIPTION_ID")
-    AZURE_UAMI_RESOURCE_ID: str = os.getenv("AZURE_UAMI_RESOURCE_ID")
+    AZURE_SUBSCRIPTION_ID: str = _require_env("AZURE_SUBSCRIPTION_ID")
+    AZURE_UAMI_RESOURCE_ID: str = _require_env("AZURE_UAMI_RESOURCE_ID")
 
     AZURE_BLOB_STORAGE_HTTPS_URL: str = "https://doppabs.blob.core.windows.net"
     AZURE_BLOB_STORAGE_ACCOUNT_NAME: str = "doppabs"
-    AZURE_BLOB_STORAGE_CONNECTION_STRING: str = os.getenv(
+    AZURE_BLOB_STORAGE_CONNECTION_STRING: str = _require_env(
         "AZURE_BLOB_STORAGE_CONNECTION_STRING"
     )
     AZURE_BLOB_STORAGE_MAX_CONCURRENCY: int = 1
@@ -32,12 +39,10 @@ class Config:
     )
 
     # POSTGRESQL
-    POSTGRES_USERNAME: str = os.getenv("POSTGRES_USERNAME")
-    POSTGRES_PASSWORD: str = os.getenv("POSTGRES_PASSWORD")
-    POSTGRES_SERVER_NAME: str = os.getenv("POSTGRES_SERVER_NAME")
-    POSTGRES_HOST: str = (
-        f"{os.getenv('POSTGRES_SERVER_NAME')}.postgres.database.azure.com"
-    )
+    POSTGRES_USERNAME: str = _require_env("POSTGRES_USERNAME")
+    POSTGRES_PASSWORD: str = _require_env("POSTGRES_PASSWORD")
+    POSTGRES_SERVER_NAME: str = _require_env("POSTGRES_SERVER_NAME")
+    POSTGRES_HOST: str = f"{POSTGRES_SERVER_NAME}.postgres.database.azure.com"
     POSTGRES_DB: str = "postgres"
     POSTGRES_PORT: int = 5432
     POSTGRES_PAGE_SIZE: int = 10_000
@@ -119,8 +124,8 @@ class Config:
     INGESTION_DELAY_SECONDS: int = 600
 
     # DATABRICKS
-    DATABRICKS_HOST: str = os.getenv("DATABRICKS_HOST")
-    DATABRICKS_TOKEN: str = os.getenv("DATABRICKS_TOKEN")
+    DATABRICKS_HOST: str = _require_env("DATABRICKS_HOST")
+    DATABRICKS_TOKEN: str = _require_env("DATABRICKS_TOKEN")
     DATABRICKS_SPARK_VERSION: str = os.getenv(
         "DATABRICKS_SPARK_VERSION", "15.4.x-scala2.12"
     )
@@ -151,4 +156,4 @@ class Config:
     )
     DATABRICKS_MUNICIPALITIES_FILE: str = "municipalities.parquet"
     MUNICIPALITIES_CONTRIBUTION_BLOB: str = "municipalities.parquet"
-    AZURE_BLOB_STORAGE_ACCOUNT_KEY: str = os.getenv("AZURE_BLOB_STORAGE_ACCOUNT_KEY")
+    AZURE_BLOB_STORAGE_ACCOUNT_KEY: str = _require_env("AZURE_BLOB_STORAGE_ACCOUNT_KEY")


### PR DESCRIPTION
This pull request strengthens environment variable handling, updates documentation to reflect new resource allocations and timeout limits, and cleans up benchmark experiment metadata. The most important changes are summarized below:

**Configuration Hardening:**

* Introduced a `_require_env` helper in `src/config.py` to enforce that all critical environment variables are set at runtime, raising an error if any are missing. Updated all Azure, PostgreSQL, and Databricks credentials and connection strings in `Config` to use this function instead of `os.getenv`, improving reliability and early failure on misconfiguration. [[1]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592R12-R18) [[2]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592L20-R32) [[3]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592L35-R45) [[4]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592L122-R128) [[5]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592L154-R159)

**Documentation Updates:**

* Increased the documented hard cap for benchmark runs from 90 minutes (5400s) to 6 hours (21600s) in `README.md` to match code changes.
* Updated hardware specs in `README.md` to reflect that DuckDB and PostGIS now run with 4 vCPU and 16 GB RAM (previously 3 vCPU and 8 GB RAM), ensuring documentation matches the current deployment.

**Benchmark Metadata Cleanup:**

* Removed or emptied obsolete or incorrect `related_script_ids` entries from several experiments in `benchmarks.yml` to accurately reflect script associations and avoid confusion. [[1]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L249) [[2]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L276-R275) [[3]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L319) [[4]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L340) [[5]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L369-R364) [[6]](diffhunk://#diff-9a6d8e42b79fe9069a99ee980cf4877b6774af72dffc7581f4d0f376982046a5L415)